### PR TITLE
statusmodule: add component INF_DeviceType

### DIFF
--- a/zera-modules/statusmodule/src/statusmoduleinit.h
+++ b/zera-modules/statusmodule/src/statusmoduleinit.h
@@ -110,6 +110,7 @@ private:
     QString m_sReleaseNumber;
     QString m_sAdjStatus;
     QString m_sAdjChksum;
+    QString m_sDeviceType;
 
     cVeinModuleParameter *m_pPCBServerVersion;
     cVeinModuleParameter *m_pCtrlVersion;
@@ -118,10 +119,12 @@ private:
     cVeinModuleParameter *m_pDSPServerVersion;
     cVeinModuleParameter *m_pDSPProgramVersion;
     cVeinModuleParameter *m_pReleaseNumber;
+    cVeinModuleParameter *m_pDeviceType;
     cVeinModuleParameter *m_pAdjustmentStatus;
     cVeinModuleParameter *m_pAdjustmentChksum;
 
     QString findReleaseNr();
+    QString findDeviceType();
     void setInterfaceComponents();
 
 private slots:


### PR DESCRIPTION
See commit message for more details.

* Tested with vf-debugger
* To be honest: I have no idea if SCPI access works or if the field name 'DEVTYPE' conflicts with SCPI conventions
