### PR TITLE
Add ZeraMcontrollerBase as base class for all µController I2C communi…

### DIFF
--- a/zera-dev/CMakeLists.txt
+++ b/zera-dev/CMakeLists.txt
@@ -48,6 +48,8 @@ target_link_libraries(zeradev
     PRIVATE
     Qt5::Core
     zerai2c
+    zeramath
+    zeramisc
     )
 
 
@@ -58,6 +60,7 @@ target_include_directories(zeradev
     $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
     PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_SOURCE_DIR}/zera-misc
     )
 
 #set target Version

--- a/zera-dev/protocol_zera_bootloader.h
+++ b/zera-dev/protocol_zera_bootloader.h
@@ -1,0 +1,61 @@
+#ifndef PROTOCOL_ZERA_BOOTLOADER_H
+#define PROTOCOL_ZERA_BOOTLOADER_H
+
+/**
+ * ZERA bootloader protocol definitions for µCs. For mor details see [1]
+ * [1] smb://s-zera-stor01/data/EntwHard/Libraries/Atmel%20AVR/Docs/Bootloader.doc
+ */
+
+#include "dev_global.h"
+
+/**
+ * @brief Bootloader command codes
+ */
+enum bl_cmdcode
+{
+    blReadInfo = 0x00,
+    blStartProgram = 0x01,
+    blReadFlashBlock = 0x10,
+    blReadEEPromBlock = 0x11,
+    blReadAdressPointer = 0x12,
+    blWriteFlashBlock = 0x20,
+    blWriteEEPromBlock = 0x21,
+    blWriteAddressPointer = 0x22
+};
+
+/**
+ * @brief Bootloader command structure
+ */
+struct bl_cmd
+{
+    bl_cmd(quint8 _cmdcode, quint8* _par, quint16 _plen)
+        : cmdlen(0), cmddata(nullptr), RM(0){
+        cmdcode = _cmdcode;
+        par = _par;
+        plen = _plen;
+    }
+    quint8 cmdcode;
+    quint8* par;
+    quint16 plen;
+    quint16 cmdlen;
+    quint8* cmddata;
+    quint16 RM;
+};
+
+/**
+ * @brief Configuration flag bit numbers reported by Read Info (ID 0x00) command
+ */
+enum enConfFlags {
+    blAutoIncr = 0, blReadCommandsAvail = 1
+};
+
+/**
+ * @brief Bootloader configuration info structure reported by Read Info (ID 0x00) command
+ */
+struct blInfo {
+    quint16 ConfigurationFlags;
+    quint16 MemPageSize;
+    uchar AdressPointerSize;
+};
+
+#endif // PROTOCOL_ZERA_BOOTLOADER_H

--- a/zera-dev/protocol_zera_hard.h
+++ b/zera-dev/protocol_zera_hard.h
@@ -1,0 +1,53 @@
+#ifndef PROTOCOL_ZERA_HARD_H
+#define PROTOCOL_ZERA_HARD_H
+
+/**
+ * ZERA hardware protocol definitions for µCs. For more details see [1]
+ * [1] smb://s-zera-stor01/data/EntwHard/Libraries/Atmel%20AVR/Docs/CommunicationProtocols.doc
+ */
+
+#include "dev_global.h"
+
+/**
+ * @brief ZERA µC command structure
+ */
+struct hw_cmd {
+    hw_cmd(quint16 _cmdcode, quint8 _device, quint8* _par, quint16 _plen)
+        : cmdlen(0), cmddata(nullptr), RM(0)
+    {
+        cmdcode = _cmdcode;
+        device = _device;
+        par = _par;
+        plen = _plen;
+    }
+    /**
+     * @brief cmdcode: Command identifying number
+     */
+    quint16 cmdcode;
+    /**
+     * @brief device: subdevice number
+     */
+    quint8 device;
+    /**
+     * @brief par: paramter data
+     */
+    quint8* par;
+    /**
+     * @brief plen: parameter length
+     */
+    quint16 plen;
+    /**
+     * @brief cmdlen: total length of command
+     */
+    quint16 cmdlen;
+    /**
+     * @brief cmddata: raw data send
+     */
+    quint8* cmddata;
+    /**
+     * @brief RM: error mask of response
+     */
+    quint16 RM;
+};
+
+#endif // PROTOCOL_ZERA_HARD_H

--- a/zera-dev/zera_mcontroller_base.cpp
+++ b/zera-dev/zera_mcontroller_base.cpp
@@ -1,0 +1,443 @@
+#include <syslog.h>
+#include <crcutils.h>
+#include <QString>
+
+#include "zera_mcontroller_base.h"
+#include "i2cutils.h"
+
+// we have this at many many places -> TODO: rework and move to a common place
+#define DEBUG1 (m_nDebugLevel & 1) // log all error messages
+#define DEBUG2 (m_nDebugLevel & 2) // log all i2c transfers
+//#define DEBUG3 (m_nDebugLevel & 4) // log all client connect/disconnects
+
+ZeraMcontrollerBase::ZeraMcontrollerBase(QString devnode, quint8 adr, quint8 debuglevel)
+    : m_pCRCGenerator(new cMaxim1WireCRC()),
+      m_sI2CDevNode(devnode),
+      m_nI2CAdr(adr),
+      m_nDebugLevel(debuglevel)
+{
+}
+
+ZeraMcontrollerBase::~ZeraMcontrollerBase()
+{
+    delete m_pCRCGenerator;
+}
+
+ZeraMcontrollerBase::atmelRM ZeraMcontrollerBase::startProgram()
+{
+    atmelRM ret;
+    struct bl_cmd blStartProgramCMD(blStartProgram, nullptr, 0);
+    if ( (writeBootloaderCommand(&blStartProgramCMD) != 0) || (blStartProgramCMD.RM) ) {
+        ret = cmdexecfault;
+    }
+    else {
+        ret = cmddone;
+    }
+    return ret;
+}
+
+ZeraMcontrollerBase::atmelRM ZeraMcontrollerBase::loadFlash(cIntelHexFileIO &ihxFIO)
+{
+    return loadMemory(blWriteFlashBlock, ihxFIO);
+}
+
+ZeraMcontrollerBase::atmelRM ZeraMcontrollerBase::loadEEprom(cIntelHexFileIO &ihxFIO)
+{
+    return loadMemory(blWriteEEPromBlock, ihxFIO);
+}
+
+ZeraMcontrollerBase::atmelRM ZeraMcontrollerBase::mGetText(quint16 hwcmd, QString& answer)
+{
+    quint8 PAR[1];
+    atmelRM ret = cmdexecfault;
+
+    struct hw_cmd CMD(hwcmd, 0, PAR, 0 );
+    qint16 bytesToRead = writeCommand(&CMD);
+
+    if ( bytesToRead > 0 && (CMD.RM == 0)) {
+        char *localAnsw = new char[bytesToRead];
+        qint16 bytesRead = readOutput(reinterpret_cast<quint8*>(localAnsw), static_cast<quint16>(bytesToRead));
+        if (bytesRead == bytesToRead) {
+            localAnsw[bytesToRead-1] = 0;
+            answer = localAnsw;
+            ret = cmddone;
+        }
+        delete [] localAnsw;
+    }
+    return ret;
+}
+
+qint16 ZeraMcontrollerBase::writeCommand(hw_cmd * hc, quint8 *dataReceive, quint16 dataAndCrcLenAndCrcLen)
+{
+    qint16 rlen = -1; // return value ; < 0 means error
+    quint8 inpBuf[5]; // the answer always has 5 bytes
+
+    GenCommand(hc);
+
+    // Send command and receive response (= error + length of data available for further read)
+    struct i2c_msg Msgs[2];
+    // send cmd
+    Msgs[0].addr = m_nI2CAdr;
+    Msgs[0].flags = 0;
+    Msgs[0].len = hc->cmdlen;
+    Msgs[0].buf = hc->cmddata;
+    // receive cmd response
+    Msgs[1].addr = m_nI2CAdr;
+    Msgs[1].flags = I2C_M_RD + I2C_M_NOSTART;
+    Msgs[1].len = 5;
+    Msgs[1].buf = inpBuf;
+    // i2c transaction data
+    struct i2c_rdwr_ioctl_data comData;
+    comData.msgs = Msgs;
+    comData.nmsgs = 2;
+    // Logging data
+    QString i2cHexParam;
+    if (DEBUG1 || DEBUG2) {
+        quint16 iByte;
+        for(iByte=0; iByte<hc->plen; iByte++) {
+           i2cHexParam += QString("0x%1 ").arg(hc->par[iByte], 2, 16, QLatin1Char('0'));
+        }
+    }
+    if (DEBUG2) {
+        syslog(LOG_INFO,"i2c cmd start: adr 0x%02X / cmd 0x%04X / dev 0x%02X / par %s / len %i",
+               m_nI2CAdr, hc->cmdcode, hc->device, qPrintable(i2cHexParam), dataAndCrcLenAndCrcLen);
+    }
+
+    int errVal = I2CTransfer(m_sI2CDevNode, m_nI2CAdr, m_nDebugLevel, &comData);
+    if (!errVal) { // if no error
+        // Checksum OK?
+        quint8 expectedCrc = m_pCRCGenerator->CalcBlockCRC(inpBuf, 4);
+        quint8 receivedCrc = inpBuf[4];
+        if (expectedCrc==receivedCrc) {
+            hc->RM = static_cast<quint16>(inpBuf[0] << 8) + inpBuf[1];
+            // Error mask ok?
+            if (hc->RM == 0) {
+                rlen = static_cast<qint16>((inpBuf[2] << 8) + inpBuf[3]);
+                if(DEBUG2) {
+                    syslog(LOG_INFO, "i2c cmd ok: adr 0x%02X / mask 0x%04X / len %i",
+                           m_nI2CAdr, hc->RM, rlen);
+                }
+                // Read cmd data?
+                if(dataReceive) {
+                    if(rlen == dataAndCrcLenAndCrcLen) {
+                        // readOutput logs -> no need to add logs here
+                        rlen = readOutput(dataReceive, dataAndCrcLenAndCrcLen);
+                    }
+                    else if(DEBUG1) {
+                        syslog(LOG_ERR,"i2c cmd was: adr 0x%02X / cmd 0x%04X / dev 0x%02X / par %s / len %i",
+                               m_nI2CAdr, hc->cmdcode, hc->device, qPrintable(i2cHexParam), dataAndCrcLenAndCrcLen);
+                        syslog(LOG_ERR, "i2c cmd returned wrong length: adr 0x%02X / expected len %i / received len %i",
+                               m_nI2CAdr, dataAndCrcLenAndCrcLen, rlen);
+                    }
+                }
+            }
+            else if(DEBUG1) {
+                syslog(LOG_ERR,"i2c cmd was: adr 0x%02X / cmd 0x%04X / dev 0x%02X / par %s",
+                       m_nI2CAdr, hc->cmdcode, hc->device, qPrintable(i2cHexParam));
+                syslog(LOG_ERR, "i2c cmd error: adr 0x%02X / mask 0x%04X",
+                       m_nI2CAdr, hc->RM);
+            }
+        }
+        else if (DEBUG1) {
+            syslog(LOG_ERR,"i2c cmd was: adr 0x%02X / cmd 0x%04X / dev 0x%02X / par %s",
+                   m_nI2CAdr, hc->cmdcode, hc->device, qPrintable(i2cHexParam));
+            syslog(LOG_ERR, "i2c cmd checksum error: adr 0x%02X / expected 0x%02X / received: 0x%02X",
+                   m_nI2CAdr, expectedCrc, receivedCrc);
+        }
+    }
+    else if (DEBUG1) {
+        syslog(LOG_ERR,"i2c cmd was: adr 0x%02X / cmd 0x%04X / dev 0x%02X / par %s",
+               m_nI2CAdr, hc->cmdcode, hc->device, qPrintable(i2cHexParam));
+        syslog(LOG_ERR, "i2c cmd failed: adr 0x%02X / error returned %i",
+               m_nI2CAdr, errVal);
+    }
+    // GenCommand allocated mem for us -> cleanup
+    delete hc->cmddata;
+    return rlen; // return -1  on error else length info
+}
+
+
+qint16 ZeraMcontrollerBase::writeBootloaderCommand(bl_cmd* blc, quint8 *dataReceive, quint16 dataAndCrcLenAndCrcLen)
+{
+    qint16 rlen = -1; // length of data avaliable / < 0 signals error
+    quint8 inpBuf[5]; // command response's length is always 5
+
+    GenBootloaderCommand(blc);
+
+    i2c_msg Msgs[2];
+    // send cmd
+    Msgs[0].addr = m_nI2CAdr;
+    Msgs[0].flags = 0;
+    Msgs[0].len = blc->cmdlen;
+    Msgs[0].buf = blc->cmddata;
+    // receive cmd response
+    Msgs[1].addr = m_nI2CAdr;
+    Msgs[1].flags = I2C_M_RD + I2C_M_NOSTART;
+    Msgs[1].len = 5;
+    Msgs[1].buf = inpBuf;
+    // i2c transaction data
+    struct i2c_rdwr_ioctl_data comData;
+    comData.msgs = Msgs;
+    comData.nmsgs = 2;
+    // Logging data
+    QString i2cHexParam;
+    quint16 iByte;
+    if (DEBUG1 || DEBUG2) {
+        for(iByte=0; iByte<blc->plen; iByte++) {
+           i2cHexParam += QString("0x%1 ").arg(blc->par[iByte], 2, 16, QLatin1Char('0'));
+        }
+    }
+    if (DEBUG2) {
+        syslog(LOG_INFO,"i2c bootcmd start: addr 0x%02X / cmd 0x%04X / par %s / len %i",
+               m_nI2CAdr, blc->cmdcode, qPrintable(i2cHexParam), dataAndCrcLenAndCrcLen);
+    }
+
+    int errVal = I2CTransfer(m_sI2CDevNode, m_nI2CAdr, m_nDebugLevel, &comData);
+    if (!errVal) { // no error?
+        // Checksum OK?
+        quint8 expectedCrc = m_pCRCGenerator->CalcBlockCRC(inpBuf, 4);
+        quint8 receivedCrc = inpBuf[4];
+        if (expectedCrc==receivedCrc) {
+            blc->RM = static_cast<quint16>(inpBuf[0] << 8) + inpBuf[1];
+            // Error mask ok?
+            if (blc->RM == 0) {
+                rlen = static_cast<qint16>((inpBuf[2] << 8) + inpBuf[3]);
+                if(DEBUG2) {
+                    syslog(LOG_INFO, "i2c bootcmd ok: adr 0x%02X / mask 0x%04X / len %i",
+                           m_nI2CAdr, blc->RM, rlen);
+                }
+                // Read cmd data?
+                if(dataReceive) {
+                    if(rlen == dataAndCrcLenAndCrcLen) {
+                        // readOutput logs -> no need to add logs here
+                        rlen = readOutput(dataReceive, dataAndCrcLenAndCrcLen);
+                    }
+                    else if(DEBUG1) {
+                        syslog(LOG_ERR,"i2c bootcmd was: adr 0x%02X / cmd 0x%04X / par %s / len %i",
+                               m_nI2CAdr, blc->cmdcode, qPrintable(i2cHexParam), dataAndCrcLenAndCrcLen);
+                        syslog(LOG_ERR, "i2c bootcmd returned wrong length: adr 0x%02X / expected len %i / received len %i",
+                               m_nI2CAdr, dataAndCrcLenAndCrcLen, rlen);
+                    }
+                }
+            }
+            else if(DEBUG1) {
+                syslog(LOG_ERR,"i2c bootcmd was: addr 0x%02X / cmd 0x%04X / par %s",
+                       m_nI2CAdr, blc->cmdcode, qPrintable(i2cHexParam));
+                syslog(LOG_ERR, "i2c bootcmd error: adr 0x%02X / mask 0x%04X",
+                       m_nI2CAdr, blc->RM);
+            }
+        }
+        else if (DEBUG1) {
+            syslog(LOG_ERR,"i2c bootcmd was: addr 0x%02X / cmd 0x%04X / par %s",
+                   m_nI2CAdr, blc->cmdcode, qPrintable(i2cHexParam));
+            syslog(LOG_ERR, "i2c bootcmd checksum error: adr 0x%02X / expected 0x%02X / received: 0x%02X",
+                   m_nI2CAdr, expectedCrc, receivedCrc);
+        }
+    }
+    else if (DEBUG1) {
+        syslog(LOG_ERR,"i2c bootcmd was: addr 0x%02X / cmd 0x%04X / par %s",
+               m_nI2CAdr, blc->cmdcode, qPrintable(i2cHexParam));
+        syslog(LOG_ERR, "i2c bootcmd failed: adr 0x%02X / error returned %i",
+               m_nI2CAdr, errVal);
+    }
+
+    // GenBootloaderCommand allocated mem for us -> cleanup
+    delete blc->cmddata;
+    return rlen; // -1 on error / number of data bytes we can fetch
+}
+
+
+qint16 ZeraMcontrollerBase::readOutput(quint8 *data, quint16 dataAndCrcLen)
+{
+    qint16 rlen = -1; // return value ; < 0 means error
+    // Parameter check: If something is wrong error is caused by a poor
+    // implementor -> generate warning always
+    if(!data) {
+        syslog(LOG_WARNING, "ZeraMcontrollerBase::readOutput: No data set for return buffer");
+        return rlen;
+    }
+    if(dataAndCrcLen < 2) {
+        syslog(LOG_WARNING, "ZeraMcontrollerBase::readOutput: Minimum buffer len is 2 (1 data + 1 crc): len %i",
+               dataAndCrcLen);
+        return rlen;
+    }
+    struct i2c_msg Msg;
+    // receive cmd data
+    Msg.addr = m_nI2CAdr;
+    Msg.flags = I2C_M_RD;
+    Msg.len = dataAndCrcLen;
+    Msg.buf = data;
+    // i2c transaction data
+    struct i2c_rdwr_ioctl_data comData;
+    comData.msgs = &Msg;
+    comData.nmsgs = 1;
+
+    if(DEBUG2) {
+        syslog(LOG_INFO,"i2c read start: adr 0x%02X / len %i+1 (CRC)",
+                m_nI2CAdr, dataAndCrcLen-1);
+    }
+    int errVal = I2CTransfer(m_sI2CDevNode, m_nI2CAdr, m_nDebugLevel, &comData);
+    if (!errVal) { // if no error
+        // Checksum OK?
+        quint8 expectedCrc = m_pCRCGenerator->CalcBlockCRC(data, dataAndCrcLen-1);
+        quint8 receivedCrc = data[dataAndCrcLen-1];
+        if (expectedCrc==receivedCrc) {
+            rlen = static_cast<qint16>(dataAndCrcLen);
+            if(DEBUG2) {
+                syslog(LOG_INFO, "i2c read ok: adr 0x%02X / len %i",
+                       m_nI2CAdr, rlen);
+            }
+        }
+        else if (DEBUG1) {
+            syslog(LOG_ERR, "i2c read checksum error: adr 0x%02X / expected 0x%02X / received: 0x%02X",
+                   m_nI2CAdr, expectedCrc, receivedCrc);
+        }
+    }
+    else if (DEBUG1) {
+        syslog(LOG_ERR, "i2c read failed: adr 0x%02X / error returned %i",
+               m_nI2CAdr, errVal);
+    }
+    return rlen; // return -1  on error else length info
+}
+
+
+void ZeraMcontrollerBase::GenCommand(hw_cmd* hc)
+{
+    if(!hc->par && hc->plen > 0) {
+        syslog(LOG_WARNING, "ZeraMcontrollerBase::GenCommand: No parameter data set but plen=%u", hc->plen);
+        hc->plen = 0;
+    }
+    quint16 len = 6 + hc->plen;
+    quint8* p = new quint8[len];
+    hc->cmddata = p;
+
+    // cmd len
+    *p++ = static_cast<quint8>(len >> 8);
+    *p++ = len & 0xFF;
+    // cmd code
+    *p++ = ((hc->cmdcode) >> 8) & 0xFF;
+    *p++ = (hc->cmdcode) & 0xFF;
+    // sub device
+    *p++ = hc->device;
+    // parameter
+    const quint8* ppar = hc->par;
+    if(ppar) {
+        for (int i = 0; i < hc->plen;i++) {
+            *p++ = *ppar++;
+        }
+    }
+    // CRC
+    *p = m_pCRCGenerator->CalcBlockCRC(hc->cmddata, static_cast<quint32>(len-1));
+    // keep cmd total len
+    hc->cmdlen = len;
+}
+
+
+void ZeraMcontrollerBase::GenBootloaderCommand(bl_cmd* blc)
+{
+    if(!blc->par && blc->plen > 0) {
+        syslog(LOG_WARNING, "ZeraMcontrollerBase::GenBootloaderCommand: No parameter data set but plen=%u", blc->plen);
+        blc->plen = 0;
+    }
+    quint16 len = 4 + blc->plen;
+    quint8* p = new quint8[len];
+    blc->cmddata = p;
+
+    // cmd code
+    *p++ = blc->cmdcode;
+    // cmd len
+    *p++ = blc->plen >> 8;
+    *p++ = blc->plen & 0xFF;
+    // parameter
+    quint8* ppar = blc->par;
+    if(ppar) {
+        for (int i = 0; i < blc->plen; i++) {
+            *p++ = *ppar++;
+        }
+    }
+    // CRC
+    *p = m_pCRCGenerator->CalcBlockCRC(blc->cmddata, len-1);
+    // keep cmd total len
+    blc->cmdlen = len;
+}
+
+
+quint8* ZeraMcontrollerBase::GenAdressPointerParameter(quint8 adresspointerSize, quint32 adr)
+{
+    quint8* par = new quint8(adresspointerSize);
+    quint8* pptr = par;
+    for (int  i = 0; i < adresspointerSize; i++) {
+        *pptr++ = static_cast<quint8>((adr >> (8* ( (adresspointerSize-1) - i)) ) & 0xff);
+    }
+    return par;
+}
+
+
+ZeraMcontrollerBase::atmelRM ZeraMcontrollerBase::loadMemory(bl_cmdcode blwriteCmd, cIntelHexFileIO& ihxFIO)
+{
+    atmelRM  ret = cmddone;
+    quint8 PAR[1];
+    struct bl_cmd blInfoCMD(blReadInfo, PAR, 0);
+
+    qint16 dataAndCrcLen = writeBootloaderCommand(&blInfoCMD);
+
+    if ( (dataAndCrcLen > 5) && (blInfoCMD.RM == 0) ) { // we must get at least 6 bytes
+        // we've got them and no error
+        dataAndCrcLen++; // dataAndCrcLen is only data lenght but we also want the crc-byte
+        quint8 blInput[255];
+        qint16 read = readOutput(blInput, static_cast<quint16>(dataAndCrcLen));
+        if ( read == dataAndCrcLen) { // we got the reqired information from bootloader
+            blInfo BootloaderInfo;
+            quint8* dest = reinterpret_cast<quint8*>(&BootloaderInfo);
+            // Note: Bootloader response starts with zero-terminated version
+            // information. Swap-copy bytes followin into BootloaderInfo
+            size_t pos = strlen(reinterpret_cast<char*>(blInput));
+            size_t i;
+            for (i = 0; i < 4; i++) {
+                dest[i ^ 1] = blInput[pos+1+i]; // little endian ... big endian
+            }
+            dest[i] = blInput[pos+1+i];
+
+            quint32 MemAdress = 0;
+            quint32 MemOffset;
+            QByteArray MemByteArray;
+
+            ihxFIO.GetMemoryBlock( BootloaderInfo.MemPageSize, MemAdress, MemByteArray, MemOffset);
+            while ( (MemByteArray.count()) && (ret == cmddone) ) { // as long we get data from hexfile
+                quint8* adrParameter;
+                quint8 adrParLen = BootloaderInfo.AdressPointerSize;
+                adrParameter = GenAdressPointerParameter(adrParLen, MemAdress);
+
+                struct bl_cmd blAdressCMD(blWriteAddressPointer, adrParameter, adrParLen);
+
+                if ( (writeBootloaderCommand(&blAdressCMD) == 0) && (blAdressCMD.RM == 0) ) {
+                    // we were able to write the adress
+                    quint8* memdat = reinterpret_cast<quint8*>(MemByteArray.data());
+                    quint16 memlen = static_cast<quint16>(MemByteArray.count());
+                    struct bl_cmd blwriteMemCMD(blwriteCmd, memdat, memlen);
+                    if ( (writeBootloaderCommand(&blwriteMemCMD) == 0) && (blwriteMemCMD.RM == 0) ) {
+                        // we were able to write the data and expect the data to be in flash when sent over i2c
+                        MemAdress += BootloaderInfo.MemPageSize;
+                        // try to get next block from hex file
+                        ihxFIO.GetMemoryBlock( BootloaderInfo.MemPageSize, MemAdress, MemByteArray, MemOffset);
+                    }
+                    else {
+                        ret = cmdexecfault;
+                    }
+                }
+                else {
+                    ret = cmdexecfault;
+                }
+                delete adrParameter;
+            }
+        }
+        else {
+            ret = cmdexecfault;
+        }
+    }
+    else {
+        ret = cmdexecfault;
+    }
+
+    return ret;
+}

--- a/zera-dev/zera_mcontroller_base.h
+++ b/zera-dev/zera_mcontroller_base.h
@@ -1,0 +1,114 @@
+#ifndef ZERA_MCONTROLLER_BASE_H
+#define ZERA_MCONTROLLER_BASE_H
+
+/**
+ * ZERA hardware protocol definitions for µCs. For mor details see [1]
+ * [1] smb://s-zera-stor01/data/EntwHard/Libraries/Atmel%20AVR/Docs/CommunicationProtocols.doc
+ */
+
+#include <QString>
+#include <crcutils.h>
+#include <intelhexfileio.h>
+
+#include "dev_global.h"
+#include "protocol_zera_bootloader.h"
+#include "protocol_zera_hard.h"
+
+/**
+ * @brief ZeraMcontrollerBase implements basic functionality for hardware-/bootloader-protocol
+ */
+class ZERADEV_EXPORT ZeraMcontrollerBase
+{
+public:
+    /**
+     * @brief Command response as handled in this scope
+     */
+    enum atmelRM
+    {
+        cmddone,
+        cmdfault,
+        cmdexecfault
+    };
+    /**
+     * @brief ZeraMcontrollerBase: constructor
+     * @param devnode: full path to i2c block-device
+     * @param adr: i2c addres of slave
+     * @param debuglevel: control verbosity of log output
+     */
+    ZeraMcontrollerBase(QString devnode, quint8 adr, quint8 debuglevel);
+    virtual ~ZeraMcontrollerBase();
+    /* bootloader is common to all controllers and should never change for
+     * compatibility -> complete interface to control bootloader
+     * can be implemented in base class
+     */
+    /**
+     * @brief startProgram: Bootloader command to start application
+     * @return
+     */
+    atmelRM startProgram();
+    atmelRM loadFlash(cIntelHexFileIO& ihxFIO);
+    atmelRM loadEEprom(cIntelHexFileIO& ihxFIO);
+    /**
+     * @brief mGetText: Function to read strings (name,version..) from controller
+     * @param hwcmd: [in] command id
+     * @param answer: [out] String read from controller
+     * @return done or error type information
+     */
+    atmelRM mGetText(quint16 hwcmd, QString& answer);
+    /**
+     * @brief writeCommand: Write command and receive command response
+     * @param hc: pointer to command struct
+     * @param dataReceive: Buffer to receive data + crc
+     * @param dataAndCrcLenAndCrcLen: Number of bytes to read (data + crc)
+     * @return -1 on error else number of bytes we can fetch as result data
+     */
+    qint16 writeCommand(hw_cmd* hc, quint8 *dataReceive=nullptr, quint16 dataAndCrcLenAndCrcLen=0);
+    /**
+     * @brief writeBootloaderCommand: Write bootloader command and receive command response
+     * @param blc: pointer to bootloader command struct
+     * @param dataReceive: Buffer to receive data + crc
+     * @param dataAndCrcLenAndCrcLen: Number of bytes to read (data + crc)
+     * @return -1 on error else number of bytes we can fetch as result data
+     */
+    qint16 writeBootloaderCommand(bl_cmd* blc, quint8 *dataReceive=nullptr, quint16 dataAndCrcLenAndCrcLen=0);
+private:
+    /**
+     * @brief readOutput: Read command result from controller
+     * @param data: Buffer to receive data + crc
+     * @param dataAndCrcLenAndCrcLen: Number of bytes to read (data + crc)
+     * @return -1 on error else number of bytes we can fetch
+     */
+    qint16 readOutput(quint8 *data, quint16 dataAndCrcLenAndCrcLen);
+    /**
+     * @brief GenCommand: Allocate & fill raw data to send in cmddata
+     * @param hc: pointer to command struct
+     */
+    void GenCommand(hw_cmd* hc);
+    /**
+     * @brief GenBootloaderCommand: Allocate & fill raw data to send in cmddata
+     * @param blc: pointer to command struct
+     */
+    void GenBootloaderCommand(bl_cmd* blc);
+    /**
+     * @brief GenAdressPointerParameter: Helper allocating and setting address pointer array used by loadMemory
+     * @param adresspointerSize: size of address in bytes
+     * @param adr: The addres to calculate array from
+     * @return: pointer to created array
+     */
+    quint8* GenAdressPointerParameter(quint8 adresspointerSize, quint32 adr);
+    /**
+     * @brief loadMemory: Let bootloader write Intel hex/eep file to controller
+     * @param blwriteCmd: cmd id: either blWriteFlashBlock or blWriteEEPromBlock
+     * @param ihxFIO: Intel hex file object
+     * @return done or error type information
+     */
+    atmelRM loadMemory(bl_cmdcode blwriteCmd, cIntelHexFileIO& ihxFIO);
+
+    cMaxim1WireCRC *m_pCRCGenerator;
+    QString m_sI2CDevNode;
+    quint8 m_nI2CAdr;
+    quint8 m_nDebugLevel;
+};
+
+
+#endif // ZERA_MCONTROLLER_BASE_H


### PR DESCRIPTION
…cation

This was taken from com5003d/mt310s2 and implements all common functionality
required to communicate to (ATMEL-)µControllers. We did

* Rework interface so that µC specific consumer implementations can be kept
  simple
* Polish/cleanup code to fix warnings spawned by modern compilers
* add full bootloader protocol implementation. This can be done because
  protocol is considered fixed for compatibilty reasons (and for devices
  shipped bootloader pages cannot be written)
* Create more verbose messages in syslog
* Write some API docs

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>