### PR TITLE
Reduce interval for all error calculator modules down to 0.5s

### DIFF
--- a/zera-modules/sec1module/src/com5003-sec1module.xml
+++ b/zera-modules/sec1module/src/com5003-sec1module.xml
@@ -34,7 +34,7 @@
                 <inp2>fo1</inp2>
                 <inp3>fo2</inp3>
             </refinput>
-            <interval>2.0</interval>
+            <interval>0.5</interval>
         </measure>
     </configuration>
     <parameter>

--- a/zera-modules/sec1module/src/com5003-sec1module2.xml
+++ b/zera-modules/sec1module/src/com5003-sec1module2.xml
@@ -37,7 +37,7 @@
                 <inp2>fo1</inp2>
                 <inp3>fo2</inp3>
             </refinput>
-            <interval>2.0</interval>
+            <interval>0.5</interval>
         </measure>
     </configuration>
     <parameter>

--- a/zera-modules/sec1module/src/mt310s2-sec1module.xml
+++ b/zera-modules/sec1module/src/mt310s2-sec1module.xml
@@ -35,7 +35,7 @@
                 <inp2>fo2</inp2>
                 <inp3>fo3</inp3>
             </refinput>
-            <interval>1.0</interval>
+            <interval>0.5</interval>
         </measure>
     </configuration>
     <parameter>

--- a/zera-modules/sem1module/src/com5003-sem1module.xml
+++ b/zera-modules/sem1module/src/com5003-sem1module.xml
@@ -26,7 +26,7 @@
                 <inp2>fo2</inp2>
                 <inp3>fo3</inp3>
             </refinput>
-            <interval>1.0</interval>
+            <interval>0.5</interval>
             <activeunits>
                 <n>3</n>
                 <unit1>MW</unit1>

--- a/zera-modules/sem1module/src/mt310s2-sem1module.xml
+++ b/zera-modules/sem1module/src/mt310s2-sem1module.xml
@@ -26,7 +26,7 @@
                 <inp2>fo2</inp2>
                 <inp3>fo3</inp3>
             </refinput>
-            <interval>1.0</interval>
+            <interval>0.5</interval>
             <activeunits>
                 <n>3</n>
                 <unit1>MW</unit1>

--- a/zera-modules/spm1module/src/com5003-spm1module.xml
+++ b/zera-modules/spm1module/src/com5003-spm1module.xml
@@ -26,7 +26,7 @@
                 <inp2>fo2</inp2>
                 <inp3>fo3</inp3>
             </refinput>
-            <interval>1.0</interval>
+            <interval>0.5</interval>
             <activeunits>
                 <n>3</n>
                 <unit1>MW</unit1>

--- a/zera-modules/spm1module/src/mt310s2-spm1module.xml
+++ b/zera-modules/spm1module/src/mt310s2-spm1module.xml
@@ -26,7 +26,7 @@
                 <inp2>fo2</inp2>
                 <inp3>fo3</inp3>
             </refinput>
-            <interval>1.0</interval>
+            <interval>0.5</interval>
             <activeunits>
                 <n>3</n>
                 <unit1>MW</unit1>


### PR DESCRIPTION
COM modules were configured with 2s intervall. That caused confusion in the
transition ARMED -> STARTED.

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>