### PR TITLE
zera-i2c/CMake: Fix dependencies

### DIFF
--- a/zera-comm/zera-i2c/CMakeLists.txt
+++ b/zera-comm/zera-i2c/CMakeLists.txt
@@ -18,7 +18,7 @@ include(FeatureSummary)
 include(GNUInstallDirs)
 
 #Find dependecies
-find_package(Qt5 COMPONENTS Gui Network CONFIG REQUIRED)
+find_package(Qt5 COMPONENTS Core CONFIG REQUIRED)
 
 
 #Sum up sources

--- a/zera-comm/zera-i2c/zerai2cConfig.cmake.in
+++ b/zera-comm/zera-i2c/zerai2cConfig.cmake.in
@@ -4,7 +4,7 @@ include(CMakeFindDependencyMacro)
 #set(my-config-var @my-config-var@)
 
 # dependencies
-find_dependency(Qt5 COMPONENTS Gui Network CONFIG REQUIRED)
+find_dependency(Qt5 COMPONENTS Core CONFIG REQUIRED)
 find_dependency(VfHelpers REQUIRED)
 find_dependency(VfComponent REQUIRED)
 find_dependency(VfEvent REQUIRED)


### PR DESCRIPTION
* zera-i2c needs QtCore only
* popped up on autobuilder: it does not have any Qt dev-packages installed
* test builds on local machine passed: the devel packages are installed there

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>