### PR TITLE
zera-misc/CMake: Fix dependencies

### DIFF
--- a/zera-misc/CMakeLists.txt
+++ b/zera-misc/CMakeLists.txt
@@ -17,7 +17,7 @@ include(FeatureSummary)
 include(GNUInstallDirs)
 
 # Find dependecies
-find_package(Qt5 COMPONENTS Gui Network CONFIG REQUIRED)
+find_package(Qt5 COMPONENTS Core CONFIG REQUIRED)
 
 if(BUILD_MODULES)
     # modules require zera-protobuf
@@ -86,8 +86,7 @@ endif(BUILD_MODULES)
 
 target_link_libraries(zeramisc 
     PRIVATE
-    Qt5::Gui
-    Qt5::Network
+    Qt5::Core
     ${DEPS_FOR_MIDULE}
 )
 

--- a/zera-misc/zeramiscConfig.cmake.in
+++ b/zera-misc/zeramiscConfig.cmake.in
@@ -4,7 +4,7 @@ include(CMakeFindDependencyMacro)
 #set(my-config-var @my-config-var@)
 
 # dependencies
-find_dependency(Qt5 COMPONENTS Gui Network CONFIG REQUIRED)
+find_dependency(Qt5 COMPONENTS Core CONFIG REQUIRED)
 
 # targets file
 include("${CMAKE_CURRENT_LIST_DIR}/zeramiscTargets.cmake")


### PR DESCRIPTION
* zera-misc needs QtCore only
* popped up on autobuilder: it does not have any Qt dev-packages installed
* test builds on local machine passed: the devel packages are installed there

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>