### PR TITLE
rangemodule: remove unused member variable m_nAdjStatus

### DIFF
--- a/zera-modules/rangemodule/src/adjustment.h
+++ b/zera-modules/rangemodule/src/adjustment.h
@@ -90,7 +90,6 @@ private:
     QHash<quint32, int> m_MsgNrCmdList;
     QTimer m_AdjustTimer;
     bool m_bAdjustTrigger;
-    quint8 m_nAdjStatus;
 
     cVeinModuleComponent *m_pAdjustmentInfo;
 


### PR DESCRIPTION
Fell over this while trying to fix wrong adjustement reported on MT310s2

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>