### PR TITLE
Block ec int longer

### DIFF
--- a/zera-modules/sec1module/src/sec1modulemeasprogram.cpp
+++ b/zera-modules/sec1module/src/sec1modulemeasprogram.cpp
@@ -155,22 +155,19 @@ cSec1ModuleMeasProgram::cSec1ModuleMeasProgram(cSec1Module* module, Zera::Proxy:
     // setting up statemachine for interrupt handling
 
     m_readIntRegisterState.addTransition(this, SIGNAL(interruptContinue()), &m_readMTCountactState);
-    m_readMTCountactState.addTransition(this, SIGNAL(interruptContinue()), &m_setECResultState);
-    m_setECResultState.addTransition(this, SIGNAL(interruptContinue()), &m_resetIntRegisterState);
-    m_resetIntRegisterState.addTransition(this, SIGNAL(interruptContinue()), &m_FinalState);
+    m_readMTCountactState.addTransition(this, SIGNAL(interruptContinue()), &m_calcResultAndResetIntState);
+    m_calcResultAndResetIntState.addTransition(this, SIGNAL(interruptContinue()), &m_FinalState);
 
     m_InterrupthandlingStateMachine.addState(&m_readIntRegisterState);
     m_InterrupthandlingStateMachine.addState(&m_readMTCountactState);
-    m_InterrupthandlingStateMachine.addState(&m_setECResultState);
-    m_InterrupthandlingStateMachine.addState(&m_resetIntRegisterState);
+    m_InterrupthandlingStateMachine.addState(&m_calcResultAndResetIntState);
     m_InterrupthandlingStateMachine.addState(&m_FinalState);
 
     m_InterrupthandlingStateMachine.setInitialState(&m_readIntRegisterState);
 
     connect(&m_readIntRegisterState, SIGNAL(entered()), SLOT(readIntRegister()));
     connect(&m_readMTCountactState, SIGNAL(entered()), SLOT(readMTCountact()));
-    connect(&m_setECResultState, SIGNAL(entered()), SLOT(setECResult()));
-    connect(&m_resetIntRegisterState, SIGNAL(entered()), SLOT(resetIntRegister()));
+    connect(&m_calcResultAndResetIntState, SIGNAL(entered()), SLOT(setECResultAndResetInt()));
 }
 
 
@@ -1483,10 +1480,15 @@ void cSec1ModuleMeasProgram::setECResult()
     m_pResultAct->setValue(QVariant(m_fResult));
     m_pEnergyAct->setValue(m_fEnergy);
     m_pEnergyFinalAct->setValue(m_fEnergy);
-
-    emit interruptContinue();
 }
 
+void cSec1ModuleMeasProgram::setECResultAndResetInt()
+{
+    // just calc -> no communication with ec
+    setECResult();
+    // enable next int
+    resetIntRegister();
+}
 
 void cSec1ModuleMeasProgram::setRating()
 {

--- a/zera-modules/sec1module/src/sec1modulemeasprogram.cpp
+++ b/zera-modules/sec1module/src/sec1modulemeasprogram.cpp
@@ -154,21 +154,23 @@ cSec1ModuleMeasProgram::cSec1ModuleMeasProgram(cSec1Module* module, Zera::Proxy:
 
     // setting up statemachine for interrupt handling
 
-    m_readIntRegisterState.addTransition(this, SIGNAL(interruptContinue()), &m_resetIntRegisterState);
-    m_resetIntRegisterState.addTransition(this, SIGNAL(interruptContinue()), &m_readMTCountactState);
+    m_readIntRegisterState.addTransition(this, SIGNAL(interruptContinue()), &m_readMTCountactState);
     m_readMTCountactState.addTransition(this, SIGNAL(interruptContinue()), &m_setECResultState);
+    m_setECResultState.addTransition(this, SIGNAL(interruptContinue()), &m_resetIntRegisterState);
+    m_resetIntRegisterState.addTransition(this, SIGNAL(interruptContinue()), &m_FinalState);
 
     m_InterrupthandlingStateMachine.addState(&m_readIntRegisterState);
-    m_InterrupthandlingStateMachine.addState(&m_resetIntRegisterState);
     m_InterrupthandlingStateMachine.addState(&m_readMTCountactState);
     m_InterrupthandlingStateMachine.addState(&m_setECResultState);
+    m_InterrupthandlingStateMachine.addState(&m_resetIntRegisterState);
+    m_InterrupthandlingStateMachine.addState(&m_FinalState);
 
     m_InterrupthandlingStateMachine.setInitialState(&m_readIntRegisterState);
 
     connect(&m_readIntRegisterState, SIGNAL(entered()), SLOT(readIntRegister()));
-    connect(&m_resetIntRegisterState, SIGNAL(entered()), SLOT(resetIntRegister()));
     connect(&m_readMTCountactState, SIGNAL(entered()), SLOT(readMTCountact()));
     connect(&m_setECResultState, SIGNAL(entered()), SLOT(setECResult()));
+    connect(&m_resetIntRegisterState, SIGNAL(entered()), SLOT(resetIntRegister()));
 }
 
 
@@ -1481,6 +1483,8 @@ void cSec1ModuleMeasProgram::setECResult()
     m_pResultAct->setValue(QVariant(m_fResult));
     m_pEnergyAct->setValue(m_fEnergy);
     m_pEnergyFinalAct->setValue(m_fEnergy);
+
+    emit interruptContinue();
 }
 
 

--- a/zera-modules/sec1module/src/sec1modulemeasprogram.h
+++ b/zera-modules/sec1module/src/sec1modulemeasprogram.h
@@ -149,8 +149,7 @@ private:
     QStateMachine m_InterrupthandlingStateMachine;
     QState m_readIntRegisterState;
     QState m_readMTCountactState;
-    QState m_setECResultState;
-    QState m_resetIntRegisterState;
+    QState m_calcResultAndResetIntState;
     QFinalState m_FinalState;
 
     Zera::Proxy::cProxyClient* m_pRMClient;
@@ -268,6 +267,7 @@ private slots:
     void readMTCountact();
     void setECResult();
     void setRating();
+    void setECResultAndResetInt();
 
     void newStartStop(QVariant startstop);
     void newMode(QVariant mode);

--- a/zera-modules/sec1module/src/sec1modulemeasprogram.h
+++ b/zera-modules/sec1module/src/sec1modulemeasprogram.h
@@ -148,9 +148,10 @@ private:
     // statemachine for interrupthandling;
     QStateMachine m_InterrupthandlingStateMachine;
     QState m_readIntRegisterState;
-    QState m_resetIntRegisterState;
     QState m_readMTCountactState;
-    QFinalState m_setECResultState;
+    QState m_setECResultState;
+    QState m_resetIntRegisterState;
+    QFinalState m_FinalState;
 
     Zera::Proxy::cProxyClient* m_pRMClient;
     Zera::Proxy::cProxyClient* m_pSECClient;


### PR DESCRIPTION
@plohmer: Fixes continuous measurement (see device on my desk) - but please review and let me know what the state m_readIntRegisterState is for: m_nIntReg is written in handler but not used anywhere.