### PR TITLE
scpimodule: Fix *idn? according to John's report

### DIFF
--- a/zera-basemodule/basemodule.cpp
+++ b/zera-basemodule/basemodule.cpp
@@ -440,6 +440,23 @@ QString cBaseModule::getReleaseNr(QString path)
     return releaseNr;
 }
 
+QString cBaseModule::getSerialNr(QString path)
+{
+    // This is an alternate solution to StatusModule/PAR_SerialNr because
+    // statusmodule serves writing of serial number either. Optional writing
+    // done by zera-setup2 and in case of success a file
+    // /opt/zera/conf/serialnumber (see SerialNoInfoFilePath) is created
+    QString serialNo = "";
+
+    QFile file(path);
+    if (file.open(QIODevice::ReadOnly)) {
+        QTextStream stream(&file);
+        serialNo = stream.readLine();
+        file.close();
+    }
+    return serialNo;
+}
+
 
 void cBaseModule::entryIdle()
 {

--- a/zera-basemodule/basemodule.h
+++ b/zera-basemodule/basemodule.h
@@ -59,6 +59,7 @@ public:
     virtual QString getSCPIModuleName();
     virtual quint16 getModuleNr();
     virtual QString getReleaseNr(QString path);
+    virtual QString getSerialNr(QString path);
     virtual QByteArray getConfiguration() const = 0;
     virtual bool isConfigured() const;
     virtual void startModule();

--- a/zera-modules/scpimodule/src/com5003-scpimodule.xml
+++ b/zera-modules/scpimodule/src/com5003-scpimodule.xml
@@ -16,7 +16,7 @@
             </serialdevice>
             <device>
                 <name>COM5003</name>
-                <identification>Zera GmbH KÃ¶nigswinter, COM5003, R1.0.1</identification>
+                <identification>ZERA GmbH Koenigswinter, COM5003, R1.0.1</identification>
             </device>
             <status>
                 <questionable>

--- a/zera-modules/scpimodule/src/ieee488-2.cpp
+++ b/zera-modules/scpimodule/src/ieee488-2.cpp
@@ -222,16 +222,37 @@ void cIEEE4882::setStatusByte(quint8 stb, quint8)
 
 void cIEEE4882::setIdentification(QString ident)
 {
-    QString releaseNr;
-    releaseNr = m_pModule->getReleaseNr(ReleaseInfoFilePath);
-    if (releaseNr == "")
-        m_sIdentification = ident;
-    else
-    {
-        QStringList sl;
-        sl = ident.split(',');
-        m_sIdentification = QString("%1, %2, %3").arg(sl[0]).arg(sl[1]).arg(releaseNr);
+    QStringList splitIdent = ident.split(',');
+
+    QString companyName;
+    if(splitIdent.size() >= 1) {
+        companyName = splitIdent[0].simplified();
     }
+    if(companyName.isEmpty()) {
+        companyName = QStringLiteral("ZERA GmbH Koenigswinter");
+    }
+
+    QString model;
+    if(splitIdent.size() >= 2) {
+        model = splitIdent[1].simplified();
+    }
+    if(model.isEmpty()) {
+        model = QStringLiteral("unknown");
+    }
+
+    QString releaseNr = m_pModule->getReleaseNr(ReleaseInfoFilePath);
+    if(releaseNr.isEmpty() && splitIdent.size() >= 3) { // fallback to xml-config
+        releaseNr = splitIdent[2].simplified();
+    }
+    if(releaseNr.isEmpty()) {
+        releaseNr = QStringLiteral("unknown");
+    }
+
+    QString serialNr = m_pModule->getSerialNr(SerialNoInfoFilePath);
+    if(serialNr.isEmpty()) { // was zera-setup2 completed??
+        serialNr = QStringLiteral("unknown");
+    }
+    m_sIdentification = QString("%1, %2, %3, %4").arg(companyName).arg(model).arg(serialNr).arg(releaseNr);
 }
 
 

--- a/zera-modules/scpimodule/src/ieee488-2.h
+++ b/zera-modules/scpimodule/src/ieee488-2.h
@@ -6,7 +6,8 @@
 #include <QVector>
 
 
-#define ReleaseInfoFilePath "/opt/zera/conf/CHANGELOG"
+#define ReleaseInfoFilePath  "/opt/zera/conf/CHANGELOG"
+#define SerialNoInfoFilePath "/opt/zera/conf/serialnumber"
 
 namespace SCPIMODULE
 {
@@ -123,7 +124,7 @@ private:
 
     QVector<int> m_ErrEventQueue;
 
-    void setIdentification(QString ident);
+    void setIdentification(QString ident); // ident: default from <device>-scpimodule.xml
     QString RegOutput(quint8 reg);
     QString mGetScpiError();
 

--- a/zera-modules/scpimodule/src/mt310s2-scpimodule.xml
+++ b/zera-modules/scpimodule/src/mt310s2-scpimodule.xml
@@ -15,8 +15,8 @@
                 <device>/dev/ttyUSB0</device>
             </serialdevice>
             <device>
-                <name>MT310S2</name>
-                <identification>Zera GmbH KÃ¶nigswinter, MT310S2, R1.0.1</identification>
+                <name>MT310s2</name>
+                <identification>ZERA GmbH Koenigswinter, MT310s2, R1.0.1</identification>
             </device>
             <status>
                 <questionable>


### PR DESCRIPTION
* fix Umlaute
* add serialnumber and make use of /opt/zera/conf/serialnumber generated by
  zera-setup2
* set fallback values in case of entries missing

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>