### PR TITLE
Fix deprecation warning

### DIFF
--- a/zera-comm/zera-proxy/proxyprotobufwrapper.cpp
+++ b/zera-comm/zera-proxy/proxyprotobufwrapper.cpp
@@ -22,5 +22,5 @@ std::shared_ptr<google::protobuf::Message> cProxyProtobufWrapper::byteArrayToPro
 
 QByteArray cProxyProtobufWrapper::protobufToByteArray(const google::protobuf::Message &pMessage)
 {
-    return QByteArray(pMessage.SerializeAsString().c_str(), pMessage.ByteSize());
+    return QByteArray(pMessage.SerializeAsString().c_str(), pMessage.ByteSizeLong());
 }


### PR DESCRIPTION
| <...>/proxyprotobufwrapper.cpp:25: warning: 'ByteSize' is deprecated: Please use ByteSizeLong() instead

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>