### PR TITLE
sem1module/sep1module: recalc result on unit change at READY state

### DIFF
--- a/zera-modules/sem1module/src/sem1modulemeasprogram.cpp
+++ b/zera-modules/sem1module/src/sem1modulemeasprogram.cpp
@@ -884,6 +884,12 @@ void cSem1ModuleMeasProgram::setUnits()
     m_pT0InputPar->setUnit(s);
     m_pT1InputPar->setUnit(s);
     m_pInputUnitPar->setValue(s);
+    // In case measurement is running, values are updated properly on next
+    // interrupt (tested with vf-debugger). For a measuremnt finished we have to
+    // recalc results with new units
+    if(m_nStatus == ECALCSTATUS::READY) {
+        setEMResult();
+    }
     m_pModule->exportMetaData();
 }
 

--- a/zera-modules/spm1module/src/spm1modulemeasprogram.cpp
+++ b/zera-modules/spm1module/src/spm1modulemeasprogram.cpp
@@ -884,7 +884,12 @@ void cSpm1ModuleMeasProgram::setUnits()
 
     s = getEnergyUnit();
     m_pEnergyAct->setUnit(s);
-
+    // In case measurement is running, values are updated properly on next
+    // interrupt (tested with vf-debugger). For a measuremnt finished we have to
+    // recalc results with new units
+    if(m_nStatus == ECALCSTATUS::READY) {
+        setEMResult();
+    }
     m_pModule->exportMetaData();
 }
 


### PR DESCRIPTION
This is a valid use case: A measurement was run and user changes unit.
Currently the units are changes but the error value remains unchanged and is
then incorrect.

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>