### PR TITLE
Fix Start-/Stop measurement

### DIFF
--- a/zera-modules/sem1module/src/sem1modulemeasprogram.cpp
+++ b/zera-modules/sem1module/src/sem1modulemeasprogram.cpp
@@ -1249,7 +1249,7 @@ void cSem1ModuleMeasProgram::setSync2()
 void cSem1ModuleMeasProgram::setMeaspulses()
 {
     if (m_pTargetedPar->getValue().toInt() == 0)
-        m_nMTCNTStart = std::numeric_limits<quint32>::max(); // we simply set max. time -> approx. 50 days
+        m_nMTCNTStart = std::numeric_limits<quint32>::max() - 1; // we simply set max. time -> approx. 50 days
     else
         m_nMTCNTStart = m_pMeasTimePar->getValue().toLongLong() * 1000;
 

--- a/zera-modules/spm1module/src/spm1modulemeasprogram.cpp
+++ b/zera-modules/spm1module/src/spm1modulemeasprogram.cpp
@@ -1251,7 +1251,7 @@ void cSpm1ModuleMeasProgram::setSync2()
 void cSpm1ModuleMeasProgram::setMeaspulses()
 {
     if (m_pTargetedPar->getValue().toInt() == 0)
-        m_nMTCNTStart = std::numeric_limits<quint32>::max(); // we simply set max. time -> approx. 50 days
+        m_nMTCNTStart = std::numeric_limits<quint32>::max() - 1; // we simply set max. time -> approx. 50 days
     else
         m_nMTCNTStart = m_pMeasTimePar->getValue().toLongLong() * 1000;
 


### PR DESCRIPTION
How embarrising: in

commit 7faa53a1830e786834f46e20bbb0c49addbdf5c2
Author: Andreas Müller <schnitzeltony@gmail.com>
Date:   Tue Dec 15 19:11:06 2020 +0100

    SEC/SEM modules: Fix some warnings to be taken seriously

the value

(1<<32) - 2

was replaced by

std::numeric_limits<quint32>::max()

which is different and ruining Start/Stop

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>