### PR TITLE
MultiResults: Fix thinko in calculation of standard deviation

### DIFF
--- a/zera-modules/sec1module/src/sec1modulemeasprogram.h
+++ b/zera-modules/sec1module/src/sec1modulemeasprogram.h
@@ -301,11 +301,9 @@ private:
         double m_fLastLowerLimit = qQNaN();
         double m_fLastUpperLimit = qQNaN();
         /**
-         * @note To avoid iterating whole result list to calculate statistics
-         * we keep accumulated sums required
+         * @note To avoid one iteration of all results we keep accumulated sum
          */
         double m_fAccumulSum = 0.0;
-        double m_fStdDevAccumulSquare = 0.0;
     };
     MultipleResultHelper m_multipleResultHelper;
 


### PR DESCRIPTION
We cannot use an accumulated deviation: The mean value changes on every result
and all deviations have to be calculated based on current mean value.

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>