### PR TITLE
dspinterface_p: Keep pointer to data and data type per message

### DIFF
--- a/zera-misc/dspinterface_p.cpp
+++ b/zera-misc/dspinterface_p.cpp
@@ -297,10 +297,10 @@ quint32 cDSPInterfacePrivate::dataAcquisition(cDspMeasData *memgroup)
     QString cmd, par;
     quint32 msgnr;
 
-    actMemGroup = memgroup;
-    actMemType = DSPDATA::dFloat;
     msgnr = sendCommand(cmd = QString("MEAS"), par = QString("%1").arg(memgroup->VarList(DSPDATA::vDspResult)));
     m_MsgNrCmdList[msgnr] = dataacquisition;
+    m_MsgNrMeasData[msgnr] = memgroup;
+    m_MsgNrMemType[msgnr] = DSPDATA::dFloat;
     return msgnr;
 }
 
@@ -310,10 +310,10 @@ quint32 cDSPInterfacePrivate::dspMemoryRead(cDspMeasData *memgroup, DSPDATA::dTy
     QString cmd, par;
     quint32 msgnr;
 
-    actMemGroup = memgroup;
-    actMemType = type;
     msgnr = sendCommand(cmd = QString("MEM:READ"), par = QString("%1").arg(memgroup->VarList(DSPDATA::vDspALL)));
     m_MsgNrCmdList[msgnr] = dspmemoryread;
+    m_MsgNrMeasData[msgnr] = memgroup;
+    m_MsgNrMemType[msgnr] = type;
     return msgnr;
 }
 
@@ -495,10 +495,13 @@ void cDSPInterfacePrivate::receiveAnswer(std::shared_ptr<ProtobufMessage::NetMes
             emit q->serverAnswer(lmsgnr, lreply, returnString(lmsg));
             break;
         case dataacquisition:
-        case dspmemoryread:
+        case dspmemoryread: {
+            cDspMeasData* actMemGroup = m_MsgNrMeasData.take(lmsgnr);
+            DSPDATA::dType actMemType = m_MsgNrMemType.take(lmsgnr);
             setVarData(actMemGroup, lmsg, actMemType);
             emit q->serverAnswer(lmsgnr, 0, returnString(lmsg));
             break;
+        }
 
         }
     }

--- a/zera-misc/dspinterface_p.h
+++ b/zera-misc/dspinterface_p.h
@@ -100,8 +100,8 @@ private:
 
     QStringList CycCmdList, IntCmdList;
     QList<cDspMeasData*> m_DspMemoryDataList; // eine liste mit zeigern auf dsp speicher
-    cDspMeasData* actMemGroup;
-    DSPDATA::dType actMemType;
+    QHash<quint32, cDspMeasData*> m_MsgNrMeasData;
+    QHash<quint32, DSPDATA::dType> m_MsgNrMemType;
 };
 
 }


### PR DESCRIPTION
Avoid surprises in case a module starts dataacquisition/dspmemoryread in a
syncronous sequence.

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>