### PR TITLE
power1module: Introduce component PAR_FOUTn containing name of freque…

### DIFF
--- a/zera-modules/power1module/src/com5003-power1module.xml
+++ b/zera-modules/power1module/src/com5003-power1module.xml
@@ -46,7 +46,8 @@
                     <name>fo0</name>
                     <source>pmss</source>
                     <type>+-</type>
-                </fout1>
+                    <plug>fOUT1</plug>
+               </fout1>
             </output>
         </frequencyoutput>
     </configuration>

--- a/zera-modules/power1module/src/com5003-power1module2.xml
+++ b/zera-modules/power1module/src/com5003-power1module2.xml
@@ -47,6 +47,7 @@
                     <name>fo1</name>
                     <source>pmss</source>
                     <type>+-</type>
+                    <plug>fOUT2</plug>
                 </fout1>
             </output>
         </frequencyoutput>

--- a/zera-modules/power1module/src/com5003-power1module3.xml
+++ b/zera-modules/power1module/src/com5003-power1module3.xml
@@ -47,6 +47,7 @@
                     <name>fo2</name>
                     <source>pmss</source>
                     <type>+-</type>
+                    <plug>fOUT3</plug>
                 </fout1>
             </output>
         </frequencyoutput>

--- a/zera-modules/power1module/src/com5003-power1module4.xml
+++ b/zera-modules/power1module/src/com5003-power1module4.xml
@@ -54,6 +54,7 @@
                     <name>fo3</name>
                     <source>pmss</source>
                     <type>+-</type>
+                    <plug>fOUT4</plug>
                 </fout1>
             </output>
         </frequencyoutput>

--- a/zera-modules/power1module/src/com5003-power1moduleREF.xml
+++ b/zera-modules/power1module/src/com5003-power1moduleREF.xml
@@ -44,7 +44,8 @@
                     <name>fo0</name>
                     <source>pmss</source>
                     <type>+-</type>
-                </fout1>
+                    <plug>fOUT1</plug>
+               </fout1>
             </output>
         </frequencyoutput>
     </configuration>

--- a/zera-modules/power1module/src/mt310s2-power1module4.xml
+++ b/zera-modules/power1module/src/mt310s2-power1module4.xml
@@ -53,6 +53,7 @@
                     <name>fo0</name>
                     <source>pmss</source>
                     <type>+-</type>
+                    <plug>fOUT</plug>
                 </fout1>
             </output>
         </frequencyoutput>

--- a/zera-modules/power1module/src/power1module.xsd
+++ b/zera-modules/power1module/src/power1module.xsd
@@ -187,6 +187,7 @@
             <xs:element name="name" type="foutxnameType" minOccurs="1" maxOccurs="1"/>
             <xs:element name="source" type="pmsType" minOccurs="1" maxOccurs="1"/>
             <xs:element name="type" type="foutxtypeType" minOccurs="1" maxOccurs="1"/>
+            <xs:element name="plug" type="xs:string" minOccurs="0" maxOccurs="1"/>
         </xs:sequence>
     </xs:complexType>
 

--- a/zera-modules/power1module/src/power1moduleconfigdata.h
+++ b/zera-modules/power1module/src/power1moduleconfigdata.h
@@ -38,6 +38,7 @@ struct freqoutconfiguration
     QString m_sName; // system name of the used frequency output
     int m_nSource; // from xml we get pms1,2,3,s and convert to 0 .. 3
     int m_nFoutMode; // from xml we get +-,+,- we convert this to foutmodes
+    QString m_sPlug; // name of external plug if not connected: empty
 };
 
 

--- a/zera-modules/power1module/src/power1moduleconfiguration.cpp
+++ b/zera-modules/power1module/src/power1moduleconfiguration.cpp
@@ -167,6 +167,7 @@ void cPower1ModuleConfiguration::configXMLInfo(QString key)
                     m_ConfigXMLMap[QString("pow1modconfpar:configuration:frequencyoutput:output:fout%1:name").arg(i+1)] = setfreqout1Name+i;
                     m_ConfigXMLMap[QString("pow1modconfpar:configuration:frequencyoutput:output:fout%1:source").arg(i+1)] = setfreqout1Source+i;
                     m_ConfigXMLMap[QString("pow1modconfpar:configuration:frequencyoutput:output:fout%1:type").arg(i+1)] = setfreqout1Type+i;
+                    m_ConfigXMLMap[QString("pow1modconfpar:configuration:frequencyoutput:output:fout%1:plug").arg(i+1)] = setfreqout1Plug+i;
                     freqoutconfiguration fconf;
                     m_pPower1ModulConfigData->m_FreqOutputConfList.append(fconf);
                 }
@@ -244,6 +245,17 @@ void cPower1ModuleConfiguration::configXMLInfo(QString key)
                 if (s == "-")
                     fconf.m_nFoutMode = negPower;
 
+                m_pPower1ModulConfigData->m_FreqOutputConfList.replace(cmd, fconf);
+            }
+
+            else
+
+            if ((cmd >= setfreqout1Plug) && (cmd < setfreqout1Plug + 8))
+            {
+                cmd -= setfreqout1Plug;
+                freqoutconfiguration fconf;
+                fconf = m_pPower1ModulConfigData->m_FreqOutputConfList.at(cmd);
+                fconf.m_sPlug = m_pXMLReader->getValue(key);
                 m_pPower1ModulConfigData->m_FreqOutputConfList.replace(cmd, fconf);
             }
 

--- a/zera-modules/power1module/src/power1moduleconfiguration.h
+++ b/zera-modules/power1module/src/power1moduleconfiguration.h
@@ -53,7 +53,12 @@ enum moduleconfigstate
     setfreqout3Type,
     setfreqout4Type,
 
-    setnext = setfreqout1Type + 8
+    setfreqout1Plug = setfreqout1Type + 8,
+    setfreqout2Plug,
+    setfreqout3Plug,
+    setfreqout4Plug,
+
+    setnext = setfreqout1Plug + 8
 };
 
 

--- a/zera-modules/power1module/src/power1modulemeasprogram.cpp
+++ b/zera-modules/power1module/src/power1modulemeasprogram.cpp
@@ -301,20 +301,30 @@ void cPower1ModuleMeasProgram::generateInterface()
     m_pFoutCount = new cVeinModuleMetaData(QString("FOUTCount"), QVariant(m_ConfigData.m_nFreqOutputCount));
     m_pModule->veinModuleMetaDataList.append(m_pFoutCount);
 
-    cVeinModuleParameter* pFoutConstantParameter;
+    cVeinModuleParameter* pFoutParameter;
 
     if (m_ConfigData.m_nFreqOutputCount > 0)
     {
         for (int i = 0; i < m_ConfigData.m_nFreqOutputCount; i++)
         {
-            pFoutConstantParameter = new cVeinModuleParameter(m_pModule->m_nEntityId, m_pModule->m_pModuleValidator,
+            // Note: Although components are 'PAR_' they are not changable currently
+            pFoutParameter = new cVeinModuleParameter(m_pModule->m_nEntityId, m_pModule->m_pModuleValidator,
                                                               key = QString("PAR_FOUTConstant%1").arg(i),
                                                               QString("Component for querying the modules frequency output constant"),
                                                               QVariant(0));
-            pFoutConstantParameter->setSCPIInfo(new cSCPIInfo("CONFIGURATION",QString("M%1CONSTANT").arg(i), "2", pFoutConstantParameter->getName(), "0", ""));
+            pFoutParameter->setSCPIInfo(new cSCPIInfo("CONFIGURATION",QString("M%1CONSTANT").arg(i), "2", pFoutParameter->getName(), "0", ""));
 
-            m_FoutConstParameterList.append(pFoutConstantParameter);
-            m_pModule->veinModuleParameterHash[key] = pFoutConstantParameter; // for modules use
+            m_FoutConstParameterList.append(pFoutParameter);
+            m_pModule->veinModuleParameterHash[key] = pFoutParameter; // for modules use
+
+            QString foutName =  m_ConfigData.m_FreqOutputConfList.at(i).m_sPlug;
+            pFoutParameter = new cVeinModuleParameter(m_pModule->m_nEntityId, m_pModule->m_pModuleValidator,
+                                                              key = QString("PAR_FOUT%1").arg(i),
+                                                              QString("Component for querying the modules output"),
+                                                              QVariant(foutName));
+            pFoutParameter->setSCPIInfo(new cSCPIInfo("CONFIGURATION",QString("M%1OUT").arg(i), "2", pFoutParameter->getName(), "0", ""));
+
+            m_pModule->veinModuleParameterHash[key] = pFoutParameter; // for modules use
         }
     }
 

--- a/zera-modules/power2module/src/power2modulemeasprogram.cpp
+++ b/zera-modules/power2module/src/power2modulemeasprogram.cpp
@@ -309,6 +309,10 @@ void cPower2ModuleMeasProgram::generateInterface()
 
     m_pPQSCountInfo = new cVeinModuleMetaData(QString("PQSCount"), QVariant(12));
     m_pModule->veinModuleMetaDataList.append(m_pPQSCountInfo);
+    m_pNomFrequencyInfo =  new cVeinModuleMetaData(QString("NominalFrequency"), QVariant(m_ConfigData.m_nNominalFrequency));
+    m_pModule->veinModuleMetaDataList.append(m_pNomFrequencyInfo);
+    m_pFoutCount = new cVeinModuleMetaData(QString("FOUTCount"), QVariant(m_ConfigData.m_nFreqOutputCount));
+    m_pModule->veinModuleMetaDataList.append(m_pFoutCount);
 
     // a list with all possible measuring modes
     m_MeasuringModeInfoHash["4LW"] = cMeasModeInfo(tr("4LW"), "P", "W", actPower, m4lw);

--- a/zera-modules/power2module/src/power2modulemeasprogram.h
+++ b/zera-modules/power2module/src/power2modulemeasprogram.h
@@ -135,6 +135,8 @@ private:
 
     QList<cVeinModuleActvalue*> m_ActValueList; // the list of actual values we work on
     cVeinModuleMetaData* m_pPQSCountInfo; // the number of values we produce
+    cVeinModuleMetaData* m_pFoutCount; // number of our frequence outputs
+    cVeinModuleMetaData* m_pNomFrequencyInfo; // the modules nominal frequency
     cVeinModuleParameter* m_pIntegrationParameter;
     cVeinModuleParameter* m_pMeasuringmodeParameter;
     cVeinModuleComponent* m_pMeasureSignal;


### PR DESCRIPTION
…ncy output

* This  information is missing in vf-declative-gui to explain user where the
  power modules output their pulses.
* Am aware that there were plans for a routing module but honestly:
  * will we ever find time to implement it? If so the damage caused by this
    change is limited.
  * do the efforts really buy a benefit to end users?

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>