### PR TITLE
All modules: Make m_pConfiguration a shared pointer - part 2

### DIFF
--- a/zera-basemodule/basedspmeasprogram.cpp
+++ b/zera-basemodule/basedspmeasprogram.cpp
@@ -1,8 +1,8 @@
 #include "basedspmeasprogram.h"
 
 
-cBaseDspMeasProgram::cBaseDspMeasProgram(Zera::Proxy::cProxy *proxy)
-    :cBaseMeasProgram(proxy)
+cBaseDspMeasProgram::cBaseDspMeasProgram(Zera::Proxy::cProxy *proxy, std::shared_ptr<cBaseModuleConfiguration> pConfiguration)
+    : cBaseMeasProgram(proxy, pConfiguration)
 {
 }
 

--- a/zera-basemodule/basedspmeasprogram.h
+++ b/zera-basemodule/basedspmeasprogram.h
@@ -7,7 +7,7 @@ class cBaseDspMeasProgram: public cBaseMeasProgram
 {
     Q_OBJECT
 public:
-    cBaseDspMeasProgram(Zera::Proxy::cProxy* proxy);
+    cBaseDspMeasProgram(Zera::Proxy::cProxy* proxy, std::shared_ptr<cBaseModuleConfiguration> pConfiguration);
     virtual ~cBaseDspMeasProgram();
 
 protected:

--- a/zera-basemodule/basemeasprogram.cpp
+++ b/zera-basemodule/basemeasprogram.cpp
@@ -1,7 +1,7 @@
 #include "basemeasprogram.h"
 
-cBaseMeasProgram::cBaseMeasProgram(Zera::Proxy::cProxy* proxy)
-    :m_pProxy(proxy)
+cBaseMeasProgram::cBaseMeasProgram(Zera::Proxy::cProxy* proxy, std::shared_ptr<cBaseModuleConfiguration> pConfiguration)
+    : m_pProxy(proxy), m_pConfiguration(pConfiguration)
 {
 }
 

--- a/zera-basemodule/basemeasprogram.h
+++ b/zera-basemodule/basemeasprogram.h
@@ -5,8 +5,10 @@
 #include <QStringList>
 #include <QVector>
 #include <QHash>
+#include <memory>
 
 #include "moduleactivist.h"
+#include "basemoduleconfiguration.h"
 
 class cBaseModule;
 class cSocket;
@@ -31,7 +33,7 @@ class cBaseMeasProgram: public cModuleActivist
     Q_OBJECT
 
 public:
-    cBaseMeasProgram(Zera::Proxy::cProxy* proxy);
+    cBaseMeasProgram(Zera::Proxy::cProxy* proxy, std::shared_ptr<cBaseModuleConfiguration> pConfiguration);
     virtual ~cBaseMeasProgram();
     virtual void generateInterface() = 0; // here we export our interface (entities)
     virtual void deleteInterface() = 0; // we delete interface in case of reconfiguration
@@ -45,6 +47,7 @@ public slots:
 
 protected:
     Zera::Proxy::cProxy* m_pProxy; // the proxy where we can get our connections
+    std::shared_ptr<cBaseModuleConfiguration> m_pConfiguration;
     Zera::Server::cRMInterface* m_pRMInterface;
     Zera::Proxy::cProxyClient* m_pRMClient;
     // we hold an interface for every channel because it could be possible that our measuring

--- a/zera-basemodule/basemeasworkprogram.cpp
+++ b/zera-basemodule/basemeasworkprogram.cpp
@@ -1,7 +1,8 @@
 #include "basemeasworkprogram.h"
 
 
-cBaseMeasWorkProgram::cBaseMeasWorkProgram()
+cBaseMeasWorkProgram::cBaseMeasWorkProgram(std::shared_ptr<cBaseModuleConfiguration> pConfiguration) :
+    m_pConfiguration(pConfiguration)
 {
     m_pEventSystem = new cBaseModuleEventSystem();
 }

--- a/zera-basemodule/basemeasworkprogram.h
+++ b/zera-basemodule/basemeasworkprogram.h
@@ -6,16 +6,18 @@
 #include <QStringList>
 #include <QVector>
 #include <QHash>
+#include <memory>
 
 #include "moduleactivist.h"
 #include "basemoduleeventsystem.h"
+#include "basemoduleconfiguration.h"
 
 class cBaseMeasWorkProgram: public cModuleActivist
 {
     Q_OBJECT
 
 public:
-    cBaseMeasWorkProgram();
+    cBaseMeasWorkProgram(std::shared_ptr<cBaseModuleConfiguration> pConfiguration);
     virtual ~cBaseMeasWorkProgram();
     virtual void generateInterface() = 0; // here we export our interface (entities)
     virtual void deleteInterface() = 0; // we delete interface in case of reconfiguration
@@ -31,6 +33,7 @@ public slots:
 protected:
     QVector<float> m_ModuleActualValues; // a modules actual values
     cBaseModuleEventSystem *m_pEventSystem;
+    std::shared_ptr<cBaseModuleConfiguration> m_pConfiguration;
 };
 
 

--- a/zera-modules/adjustmentmodule/src/adjustmentmodule.cpp
+++ b/zera-modules/adjustmentmodule/src/adjustmentmodule.cpp
@@ -79,11 +79,8 @@ void cAdjustmentModule::setupModule()
 
     cBaseMeasModule::setupModule();
 
-    cAdjustmentModuleConfigData* pConfData;
-    pConfData = qobject_cast<cAdjustmentModuleConfiguration*>(m_pConfiguration.get())->getConfigurationData();
-
     // we need some program that does the job
-    m_pMeasProgram = new cAdjustmentModuleMeasProgram(this, m_pProxy, *pConfData);
+    m_pMeasProgram = new cAdjustmentModuleMeasProgram(this, m_pProxy, m_pConfiguration);
     m_ModuleActivistList.append(m_pMeasProgram);
     connect(m_pMeasProgram, SIGNAL(activated()), SIGNAL(activationContinue()));
     connect(m_pMeasProgram, SIGNAL(deactivated()), this, SIGNAL(deactivationContinue()));

--- a/zera-modules/adjustmentmodule/src/adjustmentmodulemeasprogram.cpp
+++ b/zera-modules/adjustmentmodule/src/adjustmentmodulemeasprogram.cpp
@@ -26,13 +26,14 @@
 #include "adjustmentmodule.h"
 #include "adjustmentmodulemeasprogram.h"
 #include "adjustvalidator.h"
+#include "adjustmentmoduleconfiguration.h"
 
 
 namespace ADJUSTMENTMODULE
 {
 
-cAdjustmentModuleMeasProgram::cAdjustmentModuleMeasProgram(cAdjustmentModule* module, Zera::Proxy::cProxy* proxy, cAdjustmentModuleConfigData& configdata)
-    :m_pModule(module), m_pProxy(proxy), m_ConfigData(configdata)
+cAdjustmentModuleMeasProgram::cAdjustmentModuleMeasProgram(cAdjustmentModule* module, Zera::Proxy::cProxy* proxy, std::shared_ptr<cBaseModuleConfiguration> pConfiguration)
+    :cBaseMeasWorkProgram(pConfiguration), m_pModule(module), m_pProxy(proxy)
 {
     m_pRMInterface = new Zera::Server::cRMInterface();
     m_bAuthorized = true; // per default we are authorized
@@ -177,6 +178,11 @@ void cAdjustmentModuleMeasProgram::stop()
     // and nothing to stop
 }
 
+cAdjustmentModuleConfigData *cAdjustmentModuleMeasProgram::getConfData()
+{
+    return qobject_cast<cAdjustmentModuleConfiguration*>(m_pConfiguration.get())->getConfigurationData();
+}
+
 
 void cAdjustmentModuleMeasProgram::setAdjustEnvironment(QVariant var)
 {
@@ -233,12 +239,12 @@ void cAdjustmentModuleMeasProgram::setInterfaceValidation()
     // first the validator for amplitude adjustment
     cDoubleValidator dValidator = cDoubleValidator(0, 2000,1e-7);
     adjValidatord = new cAdjustValidator3d(this);
-    for (int i = 0; i < m_ConfigData.m_nAdjustmentChannelCount; i++)
+    for (int i = 0; i < getConfData()->m_nAdjustmentChannelCount; i++)
     {
-        sysName = m_ConfigData.m_AdjChannelList.at(i);
-        if (m_ConfigData.m_AdjChannelInfoHash[sysName]->amplitudeAdjInfo.m_bAvail)
+        sysName = getConfData()->m_AdjChannelList.at(i);
+        if (getConfData()->m_AdjChannelInfoHash[sysName]->amplitudeAdjInfo.m_bAvail)
         {
-            adjChnInfo = m_adjustChannelInfoHash[m_ConfigData.m_AdjChannelList.at(i)];
+            adjChnInfo = m_adjustChannelInfoHash[getConfData()->m_AdjChannelList.at(i)];
             adjValidatord->addValidator(adjChnInfo->m_sAlias, adjChnInfo->m_sRangelist, dValidator);
         }
     }
@@ -246,12 +252,12 @@ void cAdjustmentModuleMeasProgram::setInterfaceValidation()
 
     // validator for offset adjustment
     adjValidatord = new cAdjustValidator3d(this);
-    for (int i = 0; i < m_ConfigData.m_nAdjustmentChannelCount; i++)
+    for (int i = 0; i < getConfData()->m_nAdjustmentChannelCount; i++)
     {
-        sysName = m_ConfigData.m_AdjChannelList.at(i);
-        if (m_ConfigData.m_AdjChannelInfoHash[sysName]->offsetAdjInfo.m_bAvail)
+        sysName = getConfData()->m_AdjChannelList.at(i);
+        if (getConfData()->m_AdjChannelInfoHash[sysName]->offsetAdjInfo.m_bAvail)
         {
-            adjChnInfo = m_adjustChannelInfoHash[m_ConfigData.m_AdjChannelList.at(i)];
+            adjChnInfo = m_adjustChannelInfoHash[getConfData()->m_AdjChannelList.at(i)];
             adjValidatord->addValidator(adjChnInfo->m_sAlias, adjChnInfo->m_sRangelist, dValidator);
         }
     }
@@ -260,12 +266,12 @@ void cAdjustmentModuleMeasProgram::setInterfaceValidation()
     // validator for angle adjustment
     dValidator = cDoubleValidator(0, 360,1e-7);
     adjValidatord = new cAdjustValidator3d(this);
-    for (int i = 0; i < m_ConfigData.m_nAdjustmentChannelCount; i++)
+    for (int i = 0; i < getConfData()->m_nAdjustmentChannelCount; i++)
     {
-        sysName = m_ConfigData.m_AdjChannelList.at(i);
-        if (m_ConfigData.m_AdjChannelInfoHash[sysName]->phaseAdjInfo.m_bAvail)
+        sysName = getConfData()->m_AdjChannelList.at(i);
+        if (getConfData()->m_AdjChannelInfoHash[sysName]->phaseAdjInfo.m_bAvail)
         {
-            adjChnInfo = m_adjustChannelInfoHash[m_ConfigData.m_AdjChannelList.at(i)];
+            adjChnInfo = m_adjustChannelInfoHash[getConfData()->m_AdjChannelList.at(i)];
             adjValidatord->addValidator(adjChnInfo->m_sAlias, adjChnInfo->m_sRangelist, dValidator);
         }
     }
@@ -275,9 +281,9 @@ void cAdjustmentModuleMeasProgram::setInterfaceValidation()
     cIntValidator iValidator = cIntValidator(0,255);
 
     adjValidatori = new cAdjustValidator3i(this);
-    for (int i = 0; i < m_ConfigData.m_nAdjustmentChannelCount; i++)
+    for (int i = 0; i < getConfData()->m_nAdjustmentChannelCount; i++)
     {
-        adjChnInfo = m_adjustChannelInfoHash[m_ConfigData.m_AdjChannelList.at(i)];
+        adjChnInfo = m_adjustChannelInfoHash[getConfData()->m_AdjChannelList.at(i)];
         adjValidatori->addValidator(adjChnInfo->m_sAlias, adjChnInfo->m_sRangelist, iValidator);
     }
     m_pPARAdjustGainStatus->setValidator(adjValidatori);
@@ -289,9 +295,9 @@ void cAdjustmentModuleMeasProgram::setInterfaceValidation()
     cAdjustValidator2* adjInitValidator;
 
     adjInitValidator = new cAdjustValidator2(this);
-    for (int i = 0; i < m_ConfigData.m_nAdjustmentChannelCount; i++)
+    for (int i = 0; i < getConfData()->m_nAdjustmentChannelCount; i++)
     {
-        adjChnInfo = m_adjustChannelInfoHash[m_ConfigData.m_AdjChannelList.at(i)];
+        adjChnInfo = m_adjustChannelInfoHash[getConfData()->m_AdjChannelList.at(i)];
         adjInitValidator->addValidator(adjChnInfo->m_sAlias, adjChnInfo->m_sRangelist);
     }
     m_pPARAdjustInit->setValidator(adjInitValidator);
@@ -478,7 +484,7 @@ void cAdjustmentModuleMeasProgram::rmConnect()
 {
     // we instantiate a working resource manager interface first
     // so first we try to get a connection to resource manager over proxy
-    m_pRMClient = m_pProxy->getConnection(m_ConfigData.m_RMSocket.m_sIP, m_ConfigData.m_RMSocket.m_nPort);
+    m_pRMClient = m_pProxy->getConnection(getConfData()->m_RMSocket.m_sIP, getConfData()->m_RMSocket.m_nPort);
     m_rmConnectState.addTransition(m_pRMClient, SIGNAL(connected()), &m_IdentifyState);
     // and then we set connection resource manager interface's connection
     m_pRMInterface->setClient(m_pRMClient); //
@@ -510,13 +516,13 @@ void cAdjustmentModuleMeasProgram::readResource()
 
 void cAdjustmentModuleMeasProgram::readResourceInfo()
 {
-    m_MsgNrCmdList[m_pRMInterface->getResourceInfo("SENSE", m_ConfigData.m_AdjChannelList.at(activationIt))] = readresourceinfo;
+    m_MsgNrCmdList[m_pRMInterface->getResourceInfo("SENSE", getConfData()->m_AdjChannelList.at(activationIt))] = readresourceinfo;
 }
 
 
 void cAdjustmentModuleMeasProgram::readResourceInfoLoop()
 {
-    activationIt = (activationIt + 1) % m_ConfigData.m_nAdjustmentChannelCount;
+    activationIt = (activationIt + 1) % getConfData()->m_nAdjustmentChannelCount;
     if (activationIt == 0)
         emit activationContinue();
     else
@@ -532,11 +538,11 @@ void cAdjustmentModuleMeasProgram::pcbConnection()
 
     cAdjustChannelInfo* adjustChannelInfo;
 
-    sChannel = m_ConfigData.m_AdjChannelList.at(activationIt); // the system channel name we work on
+    sChannel = getConfData()->m_AdjChannelList.at(activationIt); // the system channel name we work on
     adjustChannelInfo = new cAdjustChannelInfo();
     m_adjustChannelInfoHash[sChannel] = adjustChannelInfo;
 
-    port = m_chnPortHash[m_ConfigData.m_AdjChannelList.at(activationIt)]; // the port
+    port = m_chnPortHash[getConfData()->m_AdjChannelList.at(activationIt)]; // the port
     if (m_portChannelHash.contains(port))
     {
         // the channels share the same interface
@@ -546,7 +552,7 @@ void cAdjustmentModuleMeasProgram::pcbConnection()
     else
     {
         m_portChannelHash[port] = sChannel;
-        pcbclient = m_pProxy->getConnection(m_ConfigData.m_PCBSocket.m_sIP, port);
+        pcbclient = m_pProxy->getConnection(getConfData()->m_PCBSocket.m_sIP, port);
         m_pcbClientList.append(pcbclient);
         m_pcbConnectionState.addTransition(pcbclient, SIGNAL(connected()), &m_pcbConnectionLoopState);
         pcbInterface = new Zera::Server::cPCBInterface();
@@ -561,7 +567,7 @@ void cAdjustmentModuleMeasProgram::pcbConnection()
 
 void cAdjustmentModuleMeasProgram::pcbConnectionLoop()
 {
-    activationIt = (activationIt + 1) % m_ConfigData.m_nAdjustmentChannelCount;
+    activationIt = (activationIt + 1) % getConfData()->m_nAdjustmentChannelCount;
     if (activationIt == 0)
         emit activationContinue();
     else
@@ -573,14 +579,14 @@ void cAdjustmentModuleMeasProgram::readChnAlias()
 {
     QString name;
 
-    name = m_ConfigData.m_AdjChannelList.at(activationIt);
+    name = getConfData()->m_AdjChannelList.at(activationIt);
     m_MsgNrCmdList[m_adjustChannelInfoHash[name]->m_pPCBInterface->getAlias(name)] = readchnalias;
 }
 
 
 void cAdjustmentModuleMeasProgram::readChnAliasLoop()
 {
-    activationIt = (activationIt + 1) % m_ConfigData.m_nAdjustmentChannelCount;
+    activationIt = (activationIt + 1) % getConfData()->m_nAdjustmentChannelCount;
     if (activationIt == 0)
         emit activationContinue();
     else
@@ -592,14 +598,14 @@ void cAdjustmentModuleMeasProgram::readRangelist()
 {
     QString name;
 
-    name = m_ConfigData.m_AdjChannelList.at(activationIt);
+    name = getConfData()->m_AdjChannelList.at(activationIt);
     m_MsgNrCmdList[m_adjustChannelInfoHash[name]->m_pPCBInterface->getRangeList(name)] = readrangelist;
 }
 
 
 void cAdjustmentModuleMeasProgram::readRangelistLoop()
 {
-    activationIt = (activationIt + 1) % m_ConfigData.m_nAdjustmentChannelCount;
+    activationIt = (activationIt + 1) % getConfData()->m_nAdjustmentChannelCount;
     if (activationIt == 0)
         emit activationContinue();
     else
@@ -614,20 +620,20 @@ void cAdjustmentModuleMeasProgram::searchActualValues()
 
     error = false;
 
-    adjInfo = m_ConfigData.m_ReferenceAngle;
+    adjInfo = getConfData()->m_ReferenceAngle;
     if (!m_pModule->m_pStorageSystem->hasStoredValue(adjInfo.m_nEntity, adjInfo.m_sComponent))
         error = true;
-    adjInfo = m_ConfigData.m_ReferenceFrequency;
+    adjInfo = getConfData()->m_ReferenceFrequency;
     if (!m_pModule->m_pStorageSystem->hasStoredValue(adjInfo.m_nEntity, adjInfo.m_sComponent))
         error = true;
 
-    for (int i = 0; i < m_ConfigData.m_nAdjustmentChannelCount; i++)
+    for (int i = 0; i < getConfData()->m_nAdjustmentChannelCount; i++)
     {
         // we test if all configured actual value data exist
         QString chn;
 
-        chn = m_ConfigData.m_AdjChannelList.at(i);
-        adjInfo = m_ConfigData.m_AdjChannelInfoHash[chn]->amplitudeAdjInfo;
+        chn = getConfData()->m_AdjChannelList.at(i);
+        adjInfo = getConfData()->m_AdjChannelInfoHash[chn]->amplitudeAdjInfo;
 
         if (adjInfo.m_bAvail)
             if (!m_pModule->m_pStorageSystem->hasStoredValue(adjInfo.m_nEntity, adjInfo.m_sComponent))
@@ -636,7 +642,7 @@ void cAdjustmentModuleMeasProgram::searchActualValues()
                 break;
             }
 
-        adjInfo = m_ConfigData.m_AdjChannelInfoHash[chn]->phaseAdjInfo;
+        adjInfo = getConfData()->m_AdjChannelInfoHash[chn]->phaseAdjInfo;
 
         if (adjInfo.m_bAvail)
             if (!m_pModule->m_pStorageSystem->hasStoredValue(adjInfo.m_nEntity, adjInfo.m_sComponent))
@@ -645,7 +651,7 @@ void cAdjustmentModuleMeasProgram::searchActualValues()
                 break;
             }
 
-        adjInfo = m_ConfigData.m_AdjChannelInfoHash[chn]->offsetAdjInfo;
+        adjInfo = getConfData()->m_AdjChannelInfoHash[chn]->offsetAdjInfo;
 
         if (adjInfo.m_bAvail)
             if (!m_pModule->m_pStorageSystem->hasStoredValue(adjInfo.m_nEntity, adjInfo.m_sComponent))
@@ -826,8 +832,8 @@ void cAdjustmentModuleMeasProgram::setAdjustInitStartCommand(QVariant var)
 void cAdjustmentModuleMeasProgram::setAdjustAmplitudeStartCommand(QVariant var)
 {
     setAdjustEnvironment(var);
-    m_AdjustEntity = m_ConfigData.m_AdjChannelInfoHash[m_sAdjustSysName]->amplitudeAdjInfo.m_nEntity;
-    m_AdjustComponent = m_ConfigData.m_AdjChannelInfoHash[m_sAdjustSysName]->amplitudeAdjInfo.m_sComponent;
+    m_AdjustEntity = getConfData()->m_AdjChannelInfoHash[m_sAdjustSysName]->amplitudeAdjInfo.m_nEntity;
+    m_AdjustComponent = getConfData()->m_AdjChannelInfoHash[m_sAdjustSysName]->amplitudeAdjInfo.m_sComponent;
     m_adjustAmplitudeMachine.start();
 }
 
@@ -861,8 +867,8 @@ void cAdjustmentModuleMeasProgram::adjustamplitudeSetNode()
 void cAdjustmentModuleMeasProgram::setAdjustPhaseStartCommand(QVariant var)
 {
     setAdjustEnvironment(var);
-    m_AdjustEntity = m_ConfigData.m_AdjChannelInfoHash[m_sAdjustSysName]->phaseAdjInfo.m_nEntity;
-    m_AdjustComponent = m_ConfigData.m_AdjChannelInfoHash[m_sAdjustSysName]->phaseAdjInfo.m_sComponent;
+    m_AdjustEntity = getConfData()->m_AdjChannelInfoHash[m_sAdjustSysName]->phaseAdjInfo.m_nEntity;
+    m_AdjustComponent = getConfData()->m_AdjChannelInfoHash[m_sAdjustSysName]->phaseAdjInfo.m_sComponent;
     m_adjustPhaseMachine.start();
 }
 
@@ -870,7 +876,7 @@ void cAdjustmentModuleMeasProgram::setAdjustPhaseStartCommand(QVariant var)
 void cAdjustmentModuleMeasProgram::adjustphaseGetCorr()
 {
     m_AdjustActualValue = cmpPhase(m_pModule->m_pStorageSystem->getStoredValue(m_AdjustEntity, m_AdjustComponent));
-    m_AdjustFrequency = m_pModule->m_pStorageSystem->getStoredValue(m_ConfigData.m_ReferenceFrequency.m_nEntity, m_ConfigData.m_ReferenceFrequency.m_sComponent).toDouble();
+    m_AdjustFrequency = m_pModule->m_pStorageSystem->getStoredValue(getConfData()->m_ReferenceFrequency.m_nEntity, getConfData()->m_ReferenceFrequency.m_sComponent).toDouble();
     m_MsgNrCmdList[m_AdjustPCBInterface->getAdjPhaseCorrection(m_sAdjustSysName, m_sAdjustRange, m_AdjustFrequency)] = getadjphasecorrection;
 }
 
@@ -894,8 +900,8 @@ void cAdjustmentModuleMeasProgram::adjustphaseSetNode()
 void cAdjustmentModuleMeasProgram::setAdjustOffsetStartCommand(QVariant var)
 {
     setAdjustEnvironment(var);
-    m_AdjustEntity = m_ConfigData.m_AdjChannelInfoHash[m_sAdjustSysName]->offsetAdjInfo.m_nEntity;
-    m_AdjustComponent = m_ConfigData.m_AdjChannelInfoHash[m_sAdjustSysName]->offsetAdjInfo.m_sComponent;
+    m_AdjustEntity = getConfData()->m_AdjChannelInfoHash[m_sAdjustSysName]->offsetAdjInfo.m_nEntity;
+    m_AdjustComponent = getConfData()->m_AdjChannelInfoHash[m_sAdjustSysName]->offsetAdjInfo.m_sComponent;
     m_adjustOffsetMachine.start();
 }
 
@@ -1031,9 +1037,9 @@ void cAdjustmentModuleMeasProgram::catchInterfaceAnswer(quint32 msgnr, quint8 re
 
                     s = answer.toString();
                     allPresent = true;
-                    n = m_ConfigData.m_nAdjustmentChannelCount;
+                    n = getConfData()->m_nAdjustmentChannelCount;
                     for (int i = 0; i < n; i++)
-                        allPresent = allPresent && s.contains(m_ConfigData.m_AdjChannelList.at(i));
+                        allPresent = allPresent && s.contains(getConfData()->m_AdjChannelList.at(i));
                 }
 
                 if (allPresent)
@@ -1062,7 +1068,7 @@ void cAdjustmentModuleMeasProgram::catchInterfaceAnswer(quint32 msgnr, quint8 re
 
                     if (ok)
                     {
-                        m_chnPortHash[m_ConfigData.m_AdjChannelList.at(activationIt)] = port;
+                        m_chnPortHash[getConfData()->m_AdjChannelList.at(activationIt)] = port;
                         emit activationContinue();
                     }
 
@@ -1095,7 +1101,7 @@ void cAdjustmentModuleMeasProgram::catchInterfaceAnswer(quint32 msgnr, quint8 re
                 {
                     QString alias, sysName;
                     alias = answer.toString();
-                    sysName = m_ConfigData.m_AdjChannelList.at(activationIt);
+                    sysName = getConfData()->m_AdjChannelList.at(activationIt);
                     m_AliasChannelHash[alias] = sysName;
                     m_adjustChannelInfoHash[sysName]->m_sAlias = alias;
                     emit activationContinue();
@@ -1114,7 +1120,7 @@ void cAdjustmentModuleMeasProgram::catchInterfaceAnswer(quint32 msgnr, quint8 re
             case readrangelist:
                 if (reply == ack)
                 {
-                    m_adjustChannelInfoHash[m_ConfigData.m_AdjChannelList.at(activationIt)]->m_sRangelist = answer.toStringList();
+                    m_adjustChannelInfoHash[getConfData()->m_AdjChannelList.at(activationIt)]->m_sRangelist = answer.toStringList();
                     emit activationContinue();
                 }
                 else

--- a/zera-modules/adjustmentmodule/src/adjustmentmodulemeasprogram.h
+++ b/zera-modules/adjustmentmodule/src/adjustmentmodulemeasprogram.h
@@ -95,7 +95,7 @@ class cAdjustmentModuleMeasProgram: public cBaseMeasWorkProgram
     Q_OBJECT
 
 public:
-    cAdjustmentModuleMeasProgram(cAdjustmentModule* module, Zera::Proxy::cProxy* proxy, cAdjustmentModuleConfigData& configdata);
+    cAdjustmentModuleMeasProgram(cAdjustmentModule* module, Zera::Proxy::cProxy* proxy, std::shared_ptr<cBaseModuleConfiguration> pConfiguration);
     virtual ~cAdjustmentModuleMeasProgram();
     virtual void generateInterface(); // here we export our interface (entities)
     virtual void deleteInterface(); // we delete interface in case of reconfiguration
@@ -117,9 +117,10 @@ public slots:
     virtual void stop(); // in interface are not updated when stop
 
 private:
+    cAdjustmentModuleConfigData* getConfData();
+
     cAdjustmentModule* m_pModule;
     Zera::Proxy::cProxy* m_pProxy;
-    cAdjustmentModuleConfigData& m_ConfigData;
     Zera::Server::cPCBInterface* m_AdjustPCBInterface; //we use the following 7 parameters globally defined for easier
     QString m_sAdjustSysName; // use within statemachines ... we have to keep in mind that adjustment
     QString m_sAdjustChannel; // commands can only be used in sequence not in parallel

--- a/zera-modules/burden1module/src/burden1module.cpp
+++ b/zera-modules/burden1module/src/burden1module.cpp
@@ -79,11 +79,8 @@ void cBurden1Module::setupModule()
 
     cBaseMeasModule::setupModule();
 
-    cBurden1ModuleConfigData* pConfData;
-    pConfData = qobject_cast<cBurden1ModuleConfiguration*>(m_pConfiguration.get())->getConfigurationData();
-
     // we need some program that does the measuring on dsp
-    m_pMeasProgram = new cBurden1ModuleMeasProgram(this, *pConfData);
+    m_pMeasProgram = new cBurden1ModuleMeasProgram(this, m_pConfiguration);
     m_ModuleActivistList.append(m_pMeasProgram);
     connect(m_pMeasProgram, SIGNAL(activated()), SIGNAL(activationContinue()));
     connect(m_pMeasProgram, SIGNAL(deactivated()), this, SIGNAL(deactivationContinue()));

--- a/zera-modules/burden1module/src/burden1modulemeasprogram.h
+++ b/zera-modules/burden1module/src/burden1modulemeasprogram.h
@@ -78,7 +78,7 @@ class cBurden1ModuleMeasProgram: public cBaseMeasWorkProgram
     Q_OBJECT
 
 public:
-    cBurden1ModuleMeasProgram(cBurden1Module* module, cBurden1ModuleConfigData& configdata);
+    cBurden1ModuleMeasProgram(cBurden1Module* module, std::shared_ptr<cBaseModuleConfiguration> pConfiguration);
     virtual ~cBurden1ModuleMeasProgram();
     virtual void generateInterface(); // here we export our interface (entities)
     virtual void deleteInterface(); // we delete interface in case of reconfiguration
@@ -88,9 +88,9 @@ public slots:
     virtual void stop(); // in interface are not updated when stop
 
 private:
-    cBurden1Module* m_pModule;
-    cBurden1ModuleConfigData& m_ConfigData;
+    cBurden1ModuleConfigData* getConfData();
 
+    cBurden1Module* m_pModule;
     QList<cVeinModuleActvalue*> m_ActValueList; // the list of actual values we work on
     cVeinModuleMetaData* m_pBRSCountInfo; // the number of Burden system we are configured for
     cVeinModuleComponent* m_pMeasureSignal;

--- a/zera-modules/dftmodule/src/dftmodule.cpp
+++ b/zera-modules/dftmodule/src/dftmodule.cpp
@@ -84,7 +84,7 @@ void cDftModule::setupModule()
     pConfData = qobject_cast<cDftModuleConfiguration*>(m_pConfiguration.get())->getConfigurationData();
 
     // we need some program that does the measuring on dsp
-    m_pMeasProgram = new cDftModuleMeasProgram(this, m_pProxy, *pConfData);
+    m_pMeasProgram = new cDftModuleMeasProgram(this, m_pProxy, m_pConfiguration);
     m_ModuleActivistList.append(m_pMeasProgram);
     connect(m_pMeasProgram, SIGNAL(activated()), SIGNAL(activationContinue()));
     connect(m_pMeasProgram, SIGNAL(deactivated()), this, SIGNAL(deactivationContinue()));

--- a/zera-modules/dftmodule/src/dftmodulemeasprogram.h
+++ b/zera-modules/dftmodule/src/dftmodulemeasprogram.h
@@ -67,7 +67,7 @@ class cDftModuleMeasProgram: public cBaseDspMeasProgram
     Q_OBJECT
 
 public:
-    cDftModuleMeasProgram(cDftModule* module, Zera::Proxy::cProxy* proxy, cDftModuleConfigData& configdata);
+    cDftModuleMeasProgram(cDftModule* module, Zera::Proxy::cProxy* proxy, std::shared_ptr<cBaseModuleConfiguration> pConfiguration);
     virtual ~cDftModuleMeasProgram();
     virtual void generateInterface(); // here we export our interface (components)
     virtual void deleteInterface(); // we delete interface in case of reconfiguration
@@ -86,9 +86,9 @@ protected slots:
     virtual void catchInterfaceAnswer(quint32 msgnr, quint8 reply, QVariant answer);
 
 private:
-    cDftModule* m_pModule;
-    cDftModuleConfigData& m_ConfigData;
+    cDftModuleConfigData* getConfData();
 
+    cDftModule* m_pModule;
     QList<cVeinModuleActvalue*> m_ActValueList; // the list of actual values we work on
     cVeinModuleActvalue* m_pRFieldActualValue;
     QHash<QString, cMeasChannelInfo> m_measChannelInfoHash;

--- a/zera-modules/efficiency1module/src/efficiency1module.cpp
+++ b/zera-modules/efficiency1module/src/efficiency1module.cpp
@@ -78,11 +78,8 @@ void cEfficiency1Module::setupModule()
 
     cBaseMeasModule::setupModule();
 
-    cEfficiency1ModuleConfigData* pConfData;
-    pConfData = qobject_cast<cEfficiency1ModuleConfiguration*>(m_pConfiguration.get())->getConfigurationData();
-
     // we need some program that does the measuring on dsp
-    m_pMeasProgram = new cEfficiency1ModuleMeasProgram(this, *pConfData);
+    m_pMeasProgram = new cEfficiency1ModuleMeasProgram(this, m_pConfiguration);
     m_ModuleActivistList.append(m_pMeasProgram);
     connect(m_pMeasProgram, SIGNAL(activated()), SIGNAL(activationContinue()));
     connect(m_pMeasProgram, SIGNAL(deactivated()), this, SIGNAL(deactivationContinue()));

--- a/zera-modules/efficiency1module/src/efficiency1modulemeasprogram.h
+++ b/zera-modules/efficiency1module/src/efficiency1modulemeasprogram.h
@@ -83,7 +83,7 @@ class cEfficiency1ModuleMeasProgram: public cBaseMeasWorkProgram
     Q_OBJECT
 
 public:
-    cEfficiency1ModuleMeasProgram(cEfficiency1Module* module, cEfficiency1ModuleConfigData& configdata);
+    cEfficiency1ModuleMeasProgram(cEfficiency1Module* module, std::shared_ptr<cBaseModuleConfiguration> pConfiguration);
     virtual ~cEfficiency1ModuleMeasProgram();
     virtual void generateInterface(); // here we export our interface (entities)
     virtual void deleteInterface(); // we delete interface in case of reconfiguration
@@ -93,9 +93,9 @@ public slots:
     virtual void stop(); // in interface are not updated when stop
 
 private:
-    cEfficiency1Module* m_pModule;
-    cEfficiency1ModuleConfigData& m_ConfigData;
+    cEfficiency1ModuleConfigData* getConfData();
 
+    cEfficiency1Module* m_pModule;
     QList<cVeinModuleActvalue*> m_ActValueList; // the list of actual values we work on
     cVeinModuleMetaData* m_pEFFCountInfo; // the number of values we produce
     cVeinModuleComponent* m_pMeasureSignal;

--- a/zera-modules/fftmodule/src/fftmodule.cpp
+++ b/zera-modules/fftmodule/src/fftmodule.cpp
@@ -83,7 +83,7 @@ void cFftModule::setupModule()
     pConfData = qobject_cast<cFftModuleConfiguration*>(m_pConfiguration.get())->getConfigurationData();
 
     // we need some program that does the measuring on dsp
-    m_pMeasProgram = new cFftModuleMeasProgram(this, m_pProxy, *pConfData);
+    m_pMeasProgram = new cFftModuleMeasProgram(this, m_pProxy, m_pConfiguration);
     m_ModuleActivistList.append(m_pMeasProgram);
     connect(m_pMeasProgram, SIGNAL(activated()), SIGNAL(activationContinue()));
     connect(m_pMeasProgram, SIGNAL(deactivated()), this, SIGNAL(deactivationContinue()));

--- a/zera-modules/fftmodule/src/fftmodulemeasprogram.h
+++ b/zera-modules/fftmodule/src/fftmodulemeasprogram.h
@@ -68,7 +68,7 @@ class cFftModuleMeasProgram: public cBaseDspMeasProgram
     Q_OBJECT
 
 public:
-    cFftModuleMeasProgram(cFftModule* module, Zera::Proxy::cProxy* proxy, cFftModuleConfigData& configdata);
+    cFftModuleMeasProgram(cFftModule* module, Zera::Proxy::cProxy* proxy, std::shared_ptr<cBaseModuleConfiguration> pConfiguration);
     virtual ~cFftModuleMeasProgram();
     virtual void generateInterface(); // here we export our interface (entities)
     virtual void deleteInterface(); // we delete interface in case of reconfiguration
@@ -87,8 +87,9 @@ protected slots:
     virtual void catchInterfaceAnswer(quint32 msgnr, quint8 reply, QVariant answer);
 
 private:
+    cFftModuleConfigData* getConfData();
+
     cFftModule* m_pModule;
-    cFftModuleConfigData& m_ConfigData;
     QList<cVeinModuleActvalue*> m_ActValueList; // the list of actual values we work on
     cVeinModuleMetaData* m_pFFTCountInfo;
     cVeinModuleMetaData* m_pFFTOrderInfo;

--- a/zera-modules/lambdamodule/src/lambdamodule.cpp
+++ b/zera-modules/lambdamodule/src/lambdamodule.cpp
@@ -79,11 +79,8 @@ void cLambdaModule::setupModule()
 
     cBaseMeasModule::setupModule();
 
-    cLambdaModuleConfigData* pConfData;
-    pConfData = qobject_cast<cLambdaModuleConfiguration*>(m_pConfiguration.get())->getConfigurationData();
-
     // we need some program that does the measuring on dsp
-    m_pMeasProgram = new cLambdaModuleMeasProgram(this, *pConfData);
+    m_pMeasProgram = new cLambdaModuleMeasProgram(this, m_pConfiguration);
     m_ModuleActivistList.append(m_pMeasProgram);
     connect(m_pMeasProgram, SIGNAL(activated()), SIGNAL(activationContinue()));
     connect(m_pMeasProgram, SIGNAL(deactivated()), this, SIGNAL(deactivationContinue()));

--- a/zera-modules/lambdamodule/src/lambdamodulemeasprogram.h
+++ b/zera-modules/lambdamodule/src/lambdamodulemeasprogram.h
@@ -79,7 +79,7 @@ class cLambdaModuleMeasProgram: public cBaseMeasWorkProgram
     Q_OBJECT
 
 public:
-    cLambdaModuleMeasProgram(cLambdaModule* module, cLambdaModuleConfigData& configdata);
+    cLambdaModuleMeasProgram(cLambdaModule* module, std::shared_ptr<cBaseModuleConfiguration> pConfiguration);
     virtual ~cLambdaModuleMeasProgram();
     virtual void generateInterface(); // here we export our interface (entities)
     virtual void deleteInterface(); // we delete interface in case of reconfiguration
@@ -89,9 +89,9 @@ public slots:
     virtual void stop(); // in interface are not updated when stop
 
 private:
-    cLambdaModule* m_pModule;
-    cLambdaModuleConfigData& m_ConfigData;
+    cLambdaModuleConfigData* getConfData();
 
+    cLambdaModule* m_pModule;
     QList<cVeinModuleActvalue*> m_ActValueList; // the list of actual values we work on
     cVeinModuleMetaData* m_pLAMBDACountInfo; // the number of values we produce
     cVeinModuleComponent* m_pMeasureSignal;

--- a/zera-modules/oscimodule/src/oscimodule.cpp
+++ b/zera-modules/oscimodule/src/oscimodule.cpp
@@ -84,7 +84,7 @@ void cOsciModule::setupModule()
     pConfData = qobject_cast<cOsciModuleConfiguration*>(m_pConfiguration.get())->getConfigurationData();
 
     // we need some program that does the measuring on dsp
-    m_pMeasProgram = new cOsciModuleMeasProgram(this, m_pProxy, *pConfData);
+    m_pMeasProgram = new cOsciModuleMeasProgram(this, m_pProxy, m_pConfiguration);
     m_ModuleActivistList.append(m_pMeasProgram);
     connect(m_pMeasProgram, SIGNAL(activated()), SIGNAL(activationContinue()));
     connect(m_pMeasProgram, SIGNAL(deactivated()), this, SIGNAL(deactivationContinue()));

--- a/zera-modules/oscimodule/src/oscimodulemeasprogram.h
+++ b/zera-modules/oscimodule/src/oscimodulemeasprogram.h
@@ -66,7 +66,7 @@ class cOsciModuleMeasProgram: public cBaseDspMeasProgram
     Q_OBJECT
 
 public:
-    cOsciModuleMeasProgram(cOsciModule* module, Zera::Proxy::cProxy* proxy, cOsciModuleConfigData& configdata);
+    cOsciModuleMeasProgram(cOsciModule* module, Zera::Proxy::cProxy* proxy, std::shared_ptr<cBaseModuleConfiguration> pConfiguration);
     virtual ~cOsciModuleMeasProgram();
     virtual void generateInterface(); // here we export our interface (entities)
     virtual void deleteInterface(); // we delete interface in case of reconfiguration
@@ -85,8 +85,9 @@ protected slots:
     virtual void catchInterfaceAnswer(quint32 msgnr, quint8 reply, QVariant answer);
 
 private:
+    cOsciModuleConfigData* getConfData();
+
     cOsciModule* m_pModule;
-    cOsciModuleConfigData& m_ConfigData;
 
     QList<cVeinModuleActvalue*> m_ActValueList; // the list of actual values we work on
     cVeinModuleMetaData* m_pOsciCountInfo;

--- a/zera-modules/power1module/src/power1module.cpp
+++ b/zera-modules/power1module/src/power1module.cpp
@@ -83,7 +83,7 @@ void cPower1Module::setupModule()
     pConfData = qobject_cast<cPower1ModuleConfiguration*>(m_pConfiguration.get())->getConfigurationData();
 
     // we need some program that does the measuring on dsp
-    m_pMeasProgram = new cPower1ModuleMeasProgram(this, m_pProxy, *pConfData);
+    m_pMeasProgram = new cPower1ModuleMeasProgram(this, m_pProxy, m_pConfiguration);
     m_ModuleActivistList.append(m_pMeasProgram);
     connect(m_pMeasProgram, SIGNAL(activated()), SIGNAL(activationContinue()));
     connect(m_pMeasProgram, SIGNAL(deactivated()), this, SIGNAL(deactivationContinue()));

--- a/zera-modules/power1module/src/power1modulemeasprogram.h
+++ b/zera-modules/power1module/src/power1modulemeasprogram.h
@@ -107,7 +107,7 @@ class cPower1ModuleMeasProgram: public cBaseDspMeasProgram
     Q_OBJECT
 
 public:
-    cPower1ModuleMeasProgram(cPower1Module* module, Zera::Proxy::cProxy* proxy, cPower1ModuleConfigData& configdata);
+    cPower1ModuleMeasProgram(cPower1Module* module, Zera::Proxy::cProxy* proxy, std::shared_ptr<cBaseModuleConfiguration> pConfiguration);
     virtual ~cPower1ModuleMeasProgram();
     virtual void generateInterface(); // here we export our interface (entities)
     virtual void deleteInterface(); // we delete interface in case of reconfiguration
@@ -126,9 +126,9 @@ protected slots:
     virtual void catchInterfaceAnswer(quint32 msgnr, quint8 reply, QVariant answer);
 
 private:
-    cPower1Module* m_pModule;
-    cPower1ModuleConfigData& m_ConfigData;
+    cPower1ModuleConfigData* getConfData();
 
+    cPower1Module* m_pModule;
     QHash<QString,cMeasModeInfo> m_MeasuringModeInfoHash; // a list of all measuring modes we know with additional info
     QHash<QString, cMeasChannelInfo> m_measChannelInfoHash;
     QHash<QString, cFoutInfo> m_FoutInfoHash; // a list with frequency output information for each channel

--- a/zera-modules/power2module/src/power2module.cpp
+++ b/zera-modules/power2module/src/power2module.cpp
@@ -85,7 +85,7 @@ void cPower2Module::setupModule()
     pConfData = qobject_cast<cPower2ModuleConfiguration*>(m_pConfiguration.get())->getConfigurationData();
 
     // we need some program that does the measuring on dsp
-    m_pMeasProgram = new cPower2ModuleMeasProgram(this, m_pProxy, *pConfData);
+    m_pMeasProgram = new cPower2ModuleMeasProgram(this, m_pProxy, m_pConfiguration);
     m_ModuleActivistList.append(m_pMeasProgram);
     connect(m_pMeasProgram, SIGNAL(activated()), SIGNAL(activationContinue()));
     connect(m_pMeasProgram, SIGNAL(deactivated()), this, SIGNAL(deactivationContinue()));

--- a/zera-modules/power2module/src/power2modulemeasprogram.h
+++ b/zera-modules/power2module/src/power2modulemeasprogram.h
@@ -106,7 +106,7 @@ class cPower2ModuleMeasProgram: public cBaseDspMeasProgram
     Q_OBJECT
 
 public:
-    cPower2ModuleMeasProgram(cPower2Module* module, Zera::Proxy::cProxy* proxy, cPower2ModuleConfigData& configdata);
+    cPower2ModuleMeasProgram(cPower2Module* module, Zera::Proxy::cProxy* proxy, std::shared_ptr<cBaseModuleConfiguration> pConfiguration);
     virtual ~cPower2ModuleMeasProgram();
     virtual void generateInterface(); // here we export our interface (entities)
     virtual void deleteInterface(); // we delete interface in case of reconfiguration
@@ -125,9 +125,9 @@ protected slots:
     virtual void catchInterfaceAnswer(quint32 msgnr, quint8 reply, QVariant answer);
 
 private:
-    cPower2Module* m_pModule;
-    cPower2ModuleConfigData& m_ConfigData;
+    cPower2ModuleConfigData* getConfData();
 
+    cPower2Module* m_pModule;
     QHash<QString,cMeasModeInfo> m_MeasuringModeInfoHash; // a list of all measuring modes we know with additional info
     QHash<QString, cMeasChannelInfo> m_measChannelInfoHash;
     QHash<QString, cFoutInfo> m_FoutInfoHash; // a list with frequency output information for each channel

--- a/zera-modules/power3module/src/power3module.cpp
+++ b/zera-modules/power3module/src/power3module.cpp
@@ -79,11 +79,8 @@ void cPower3Module::setupModule()
 
     cBaseMeasModule::setupModule();
 
-    cPower3ModuleConfigData* pConfData;
-    pConfData = qobject_cast<cPower3ModuleConfiguration*>(m_pConfiguration.get())->getConfigurationData();
-
     // we need some program that does the measuring on dsp
-    m_pMeasProgram = new cPower3ModuleMeasProgram(this, *pConfData);
+    m_pMeasProgram = new cPower3ModuleMeasProgram(this, m_pConfiguration);
     m_ModuleActivistList.append(m_pMeasProgram);
     connect(m_pMeasProgram, SIGNAL(activated()), SIGNAL(activationContinue()));
     connect(m_pMeasProgram, SIGNAL(deactivated()), this, SIGNAL(deactivationContinue()));

--- a/zera-modules/power3module/src/power3modulemeasprogram.h
+++ b/zera-modules/power3module/src/power3modulemeasprogram.h
@@ -83,7 +83,7 @@ class cPower3ModuleMeasProgram: public cBaseMeasWorkProgram
     Q_OBJECT
 
 public:
-    cPower3ModuleMeasProgram(cPower3Module* module, cPower3ModuleConfigData& configdata);
+    cPower3ModuleMeasProgram(cPower3Module* module, std::shared_ptr<cBaseModuleConfiguration> pConfiguration);
     virtual ~cPower3ModuleMeasProgram();
     virtual void generateInterface(); // here we export our interface (entities)
     virtual void deleteInterface(); // we delete interface in case of reconfiguration
@@ -93,9 +93,9 @@ public slots:
     virtual void stop(); // in interface are not updated when stop
 
 private:
-    cPower3Module* m_pModule;
-    cPower3ModuleConfigData& m_ConfigData;
+    cPower3ModuleConfigData* getConfData();
 
+    cPower3Module* m_pModule;
     QList<cVeinModuleActvalue*> m_ActValueList; // the list of actual values we work on
     cVeinModuleMetaData* m_pHPWCountInfo; // the number of values we produce
     cVeinModuleComponent* m_pMeasureSignal;

--- a/zera-modules/rangemodule/src/rangemodule.cpp
+++ b/zera-modules/rangemodule/src/rangemodule.cpp
@@ -115,7 +115,7 @@ void cRangeModule::setupModule()
     connect(m_pAdjustment, SIGNAL(errMsg(QVariant)), m_pModuleErrorComponent, SLOT(setValue(QVariant)));
 
     // at last we need some program that does the measuring on dsp
-    m_pMeasProgram = new cRangeModuleMeasProgram(this, m_pProxy, *pConfData);
+    m_pMeasProgram = new cRangeModuleMeasProgram(this, m_pProxy, m_pConfiguration);
     m_ModuleActivistList.append(m_pMeasProgram);
     connect(m_pMeasProgram, SIGNAL(activated()), SIGNAL(activationContinue()));
     connect(m_pMeasProgram, SIGNAL(deactivated()), this, SIGNAL(deactivationContinue()));

--- a/zera-modules/rangemodule/src/rangemodulemeasprogram.cpp
+++ b/zera-modules/rangemodule/src/rangemodulemeasprogram.cpp
@@ -14,13 +14,14 @@
 #include "rangemodule.h"
 #include "rangemeaschannel.h"
 #include "rangemodulemeasprogram.h"
+#include "rangemoduleconfiguration.h"
 #include "rangemoduleconfigdata.h"
 
 namespace RANGEMODULE
 {
 
-cRangeModuleMeasProgram::cRangeModuleMeasProgram(cRangeModule* module, Zera::Proxy::cProxy* proxy, cRangeModuleConfigData& configData)
-    :cBaseDspMeasProgram(proxy), m_pModule(module), m_ConfigData(configData)
+cRangeModuleMeasProgram::cRangeModuleMeasProgram(cRangeModule* module, Zera::Proxy::cProxy* proxy, std::shared_ptr<cBaseModuleConfiguration> pConfiguration)
+    :cBaseDspMeasProgram(proxy, pConfiguration), m_pModule(module)
 {
     // we have to instantiate a working resource manager and dspserver interface
     m_pRMInterface = new Zera::Server::cRMInterface();
@@ -28,7 +29,7 @@ cRangeModuleMeasProgram::cRangeModuleMeasProgram(cRangeModule* module, Zera::Pro
 
     m_bRanging = false;
     m_bIgnore = false;
-    m_ChannelList = m_ConfigData.m_senseChannelList;
+    m_ChannelList = getConfData()->m_senseChannelList;
 
     m_IdentifyState.addTransition(this, SIGNAL(activationContinue()), &m_dspserverConnectState);
     m_claimPGRMemState.addTransition(this, SIGNAL(activationContinue()), &m_claimUSERMemState);
@@ -196,7 +197,7 @@ void cRangeModuleMeasProgram::setDspCmdList()
     m_pDSPInterFace->addCycListItem( s = "STARTCHAIN(1,1,0x0101)"); // aktiv, prozessnr. (dummy),hauptkette 1 subkette 1 start
         m_pDSPInterFace->addCycListItem( s = QString("CLEARN(%1,MEASSIGNAL)").arg(m_nSamples) ); // clear meassignal
         m_pDSPInterFace->addCycListItem( s = QString("CLEARN(%1,FILTER)").arg(2*(2*m_ChannelList.count()+1)+1) ); // clear the whole filter incl. count
-        m_pDSPInterFace->addCycListItem( s = QString("SETVAL(TIPAR,%1)").arg(m_ConfigData.m_fMeasInterval*1000.0)); // initial ti time  /* todo variabel */
+        m_pDSPInterFace->addCycListItem( s = QString("SETVAL(TIPAR,%1)").arg(getConfData()->m_fMeasInterval*1000.0)); // initial ti time  /* todo variabel */
         m_pDSPInterFace->addCycListItem( s = "GETSTIME(TISTART)"); // einmal ti start setzen
         m_pDSPInterFace->addCycListItem( s = QString("CLKMODE(1)")); // clk mode auf 48bit einstellen
         m_pDSPInterFace->addCycListItem( s = "DEACTIVATECHAIN(1,0x0101)"); // ende prozessnr., hauptkette 1 subkette 1
@@ -420,6 +421,11 @@ void cRangeModuleMeasProgram::catchInterfaceAnswer(quint32 msgnr, quint8 reply, 
     }
 }
 
+cRangeModuleConfigData *cRangeModuleMeasProgram::getConfData()
+{
+    return qobject_cast<cRangeModuleConfiguration*>(m_pConfiguration.get())->getConfigurationData();
+}
+
 
 void cRangeModuleMeasProgram::setActualValuesNames()
 {
@@ -463,7 +469,7 @@ void cRangeModuleMeasProgram::setInterfaceActualValues(QVector<float> *actualVal
 void cRangeModuleMeasProgram::resourceManagerConnect()
 {
     // first we try to get a connection to resource manager over proxy
-    m_pRMClient = m_pProxy->getConnection(m_ConfigData.m_RMSocket.m_sIP, m_ConfigData.m_RMSocket.m_nPort);
+    m_pRMClient = m_pProxy->getConnection(getConfData()->m_RMSocket.m_sIP, getConfData()->m_RMSocket.m_nPort);
     // and then we set connection resource manager interface's connection
     m_pRMInterface->setClient(m_pRMClient); //
     resourceManagerConnectState.addTransition(m_pRMClient, SIGNAL(connected()), &m_IdentifyState);
@@ -481,7 +487,7 @@ void cRangeModuleMeasProgram::sendRMIdent()
 
 void cRangeModuleMeasProgram::dspserverConnect()
 {
-    m_pDspClient = m_pProxy->getConnection(m_ConfigData.m_DSPServerSocket.m_sIP, m_ConfigData.m_DSPServerSocket.m_nPort);
+    m_pDspClient = m_pProxy->getConnection(getConfData()->m_DSPServerSocket.m_sIP, getConfData()->m_DSPServerSocket.m_nPort);
     m_pDSPInterFace->setClient(m_pDspClient);
     m_dspserverConnectState.addTransition(m_pDspClient, SIGNAL(connected()), &m_claimPGRMemState);
     connect(m_pDSPInterFace, SIGNAL(serverAnswer(quint32, quint8, QVariant)), this, SLOT(catchInterfaceAnswer(quint32, quint8, QVariant)));

--- a/zera-modules/rangemodule/src/rangemodulemeasprogram.h
+++ b/zera-modules/rangemodule/src/rangemodulemeasprogram.h
@@ -58,7 +58,7 @@ class cRangeModuleMeasProgram: public cBaseDspMeasProgram
     Q_OBJECT
 
 public:
-    cRangeModuleMeasProgram(cRangeModule* module,Zera::Proxy::cProxy* proxy, cRangeModuleConfigData& configData);
+    cRangeModuleMeasProgram(cRangeModule* module,Zera::Proxy::cProxy* proxy, std::shared_ptr<cBaseModuleConfiguration> pConfiguration);
     virtual ~cRangeModuleMeasProgram();
     virtual void generateInterface(); // here we export our interface (entities)
     virtual void deleteInterface(); // we delete interface in case of reconfiguration
@@ -78,6 +78,8 @@ protected slots:
     virtual void catchInterfaceAnswer(quint32 msgnr, quint8 reply, QVariant answer);
 
 private:
+    cRangeModuleConfigData* getConfData();
+
     cRangeModule* m_pModule; // the module we live in
     bool m_bRanging;
     bool m_bIgnore;
@@ -87,7 +89,6 @@ private:
     cVeinModuleComponent *m_pMeasureSignal;
     QList<cVeinModuleActvalue*> m_ActValueList;
 
-    cRangeModuleConfigData& m_ConfigData;
     cDspMeasData* m_pTmpDataDsp;
     cDspMeasData* m_pParameterDSP;
     cDspMeasData* m_pActualValuesDSP;

--- a/zera-modules/referencemodule/src/referencemodule.cpp
+++ b/zera-modules/referencemodule/src/referencemodule.cpp
@@ -127,7 +127,7 @@ void cReferenceModule::setupModule()
     }
 
     // at last we need some program that does the measuring job on dsp
-    m_pMeasProgram = new cReferenceModuleMeasProgram(this, m_pProxy, *pConfData);
+    m_pMeasProgram = new cReferenceModuleMeasProgram(this, m_pProxy, m_pConfiguration);
     m_ModuleActivistList.append(m_pMeasProgram);
     connect(m_pMeasProgram, SIGNAL(activated()), SIGNAL(activationContinue()));
     connect(m_pMeasProgram, SIGNAL(deactivated()), this, SIGNAL(deactivationContinue()));

--- a/zera-modules/referencemodule/src/referencemodulemeasprogram.h
+++ b/zera-modules/referencemodule/src/referencemodulemeasprogram.h
@@ -53,7 +53,7 @@ class cReferenceModuleMeasProgram: public cBaseDspMeasProgram
     Q_OBJECT
 
 public:
-    cReferenceModuleMeasProgram(cReferenceModule* module, Zera::Proxy::cProxy* proxy, cReferenceModuleConfigData& configData);
+    cReferenceModuleMeasProgram(cReferenceModule* module, Zera::Proxy::cProxy* proxy, std::shared_ptr<cBaseModuleConfiguration> pConfiguration);
     virtual ~cReferenceModuleMeasProgram();
     virtual void generateInterface(); // here we export our interface (entities)
     virtual void deleteInterface(); // we delete interface in case of reconfiguration
@@ -72,10 +72,11 @@ protected slots:
     virtual void catchInterfaceAnswer(quint32 msgnr, quint8 reply, QVariant answer);
 
 private:
+    cReferenceModuleConfigData* getConfData();
+
     cReferenceModule* m_pModule; // the module we live in
     quint16 m_nSamples;
     QStringList m_ChannelList; // the list of actual values we work on
-    cReferenceModuleConfigData& m_ConfigData;
     cDspMeasData* m_pTmpDataDsp;
     cDspMeasData* m_pParameterDSP;
     cDspMeasData* m_pActualValuesDSP;

--- a/zera-modules/rmsmodule/src/rmsmodule.cpp
+++ b/zera-modules/rmsmodule/src/rmsmodule.cpp
@@ -83,7 +83,7 @@ void cRmsModule::setupModule()
     pConfData = qobject_cast<cRmsModuleConfiguration*>(m_pConfiguration.get())->getConfigurationData();
 
     // we need some program that does the measuring on dsp
-    m_pMeasProgram = new cRmsModuleMeasProgram(this, m_pProxy, *pConfData);
+    m_pMeasProgram = new cRmsModuleMeasProgram(this, m_pProxy, m_pConfiguration);
     m_ModuleActivistList.append(m_pMeasProgram);
     connect(m_pMeasProgram, SIGNAL(activated()), SIGNAL(activationContinue()));
     connect(m_pMeasProgram, SIGNAL(deactivated()), this, SIGNAL(deactivationContinue()));

--- a/zera-modules/rmsmodule/src/rmsmodulemeasprogram.h
+++ b/zera-modules/rmsmodule/src/rmsmodulemeasprogram.h
@@ -67,7 +67,7 @@ class cRmsModuleMeasProgram: public cBaseDspMeasProgram
     Q_OBJECT
 
 public:
-    cRmsModuleMeasProgram(cRmsModule* module, Zera::Proxy::cProxy* proxy, cRmsModuleConfigData& configdata);
+    cRmsModuleMeasProgram(cRmsModule* module, Zera::Proxy::cProxy* proxy, std::shared_ptr<cBaseModuleConfiguration> pConfiguration);
     virtual ~cRmsModuleMeasProgram();
     virtual void generateInterface(); // here we export our interface (entities)
     virtual void deleteInterface(); // we delete interface in case of reconfiguration
@@ -86,9 +86,9 @@ protected slots:
     virtual void catchInterfaceAnswer(quint32 msgnr, quint8 reply, QVariant answer);
 
 private:
-    cRmsModule* m_pModule;
-    cRmsModuleConfigData& m_ConfigData;
+    cRmsModuleConfigData* getConfData();
 
+    cRmsModule* m_pModule;
     QList<cVeinModuleActvalue*> m_ActValueList; // the list of actual values we work on
     QHash<QString, cMeasChannelInfo> m_measChannelInfoHash;
     QList<QString> channelInfoReadList; // a list of all channel info we have to read

--- a/zera-modules/samplemodule/src/samplemodule.cpp
+++ b/zera-modules/samplemodule/src/samplemodule.cpp
@@ -121,7 +121,7 @@ void cSampleModule::setupModule()
     connect(m_pPllObsermatic, SIGNAL(errMsg(QVariant)), m_pModuleErrorComponent, SLOT(setValue(QVariant)));
 
     // at last we need some program that does the measuring on dsp
-    m_pMeasProgram = new cSampleModuleMeasProgram(this, m_pProxy, *pConfData);
+    m_pMeasProgram = new cSampleModuleMeasProgram(this, m_pProxy, m_pConfiguration);
     m_ModuleActivistList.append(m_pMeasProgram);
     connect(m_pMeasProgram, SIGNAL(activated()), SIGNAL(activationContinue()));
     connect(m_pMeasProgram, SIGNAL(deactivated()), this, SIGNAL(deactivationContinue()));

--- a/zera-modules/samplemodule/src/samplemodulemeasprogram.h
+++ b/zera-modules/samplemodule/src/samplemodulemeasprogram.h
@@ -55,7 +55,7 @@ class cSampleModuleMeasProgram: public cBaseDspMeasProgram
     Q_OBJECT
 
 public:
-    cSampleModuleMeasProgram(cSampleModule* module, Zera::Proxy::cProxy* proxy, cSampleModuleConfigData& configData);
+    cSampleModuleMeasProgram(cSampleModule* module, Zera::Proxy::cProxy* proxy, std::shared_ptr<cBaseModuleConfiguration> pConfiguration);
     virtual ~cSampleModuleMeasProgram();
     virtual void generateInterface(); // here we export our interface (entities)
     virtual void deleteInterface(); // we delete interface in case of reconfiguration
@@ -74,10 +74,11 @@ protected slots:
     virtual void catchInterfaceAnswer(quint32 msgnr, quint8 reply, QVariant answer);
 
 private:
+    cSampleModuleConfigData* getConfData();
+
     cSampleModule* m_pModule; // the module we live in
     quint16 m_nSamples;
     QStringList m_ChannelList; // the list of actual values we work on
-    cSampleModuleConfigData& m_ConfigData;
     cDspMeasData* m_pTmpDataDsp;
     cDspMeasData* m_pParameterDSP;
     cDspMeasData* m_pActualValuesDSP;

--- a/zera-modules/sec1module/src/sec1module.cpp
+++ b/zera-modules/sec1module/src/sec1module.cpp
@@ -74,11 +74,8 @@ void cSec1Module::setupModule()
     emit addEventSystem(m_pModuleValidator);
     cBaseMeasModule::setupModule();
 
-    cSec1ModuleConfigData *pConfData;
-    pConfData = qobject_cast<cSec1ModuleConfiguration*>(m_pConfiguration.get())->getConfigurationData();
-
     // we only have this activist
-    m_pMeasProgram = new cSec1ModuleMeasProgram(this, m_pProxy, *pConfData);
+    m_pMeasProgram = new cSec1ModuleMeasProgram(this, m_pProxy, m_pConfiguration);
     m_ModuleActivistList.append(m_pMeasProgram);
     connect(m_pMeasProgram, SIGNAL(activated()), SIGNAL(activationContinue()));
     connect(m_pMeasProgram, SIGNAL(deactivated()), this, SIGNAL(deactivationContinue()));

--- a/zera-modules/sec1module/src/sec1modulemeasprogram.h
+++ b/zera-modules/sec1module/src/sec1modulemeasprogram.h
@@ -88,7 +88,7 @@ class cSec1ModuleMeasProgram: public cBaseMeasProgram
     Q_OBJECT
 
 public:
-    cSec1ModuleMeasProgram(cSec1Module* module, Zera::Proxy::cProxy* proxy, cSec1ModuleConfigData& configData);
+    cSec1ModuleMeasProgram(cSec1Module* module, Zera::Proxy::cProxy* proxy, std::shared_ptr<cBaseModuleConfiguration> pConfiguration);
     virtual ~cSec1ModuleMeasProgram();
     virtual void generateInterface(); // here we export our interface (entities)
     virtual void deleteInterface(); // we delete interface in case of reconfiguration
@@ -102,9 +102,9 @@ protected slots:
     virtual void catchInterfaceAnswer(quint32 msgnr, quint8 reply, QVariant answer);
 
 private:
-    cSec1Module* m_pModule; // the module we live in
-    cSec1ModuleConfigData& m_ConfigData;
+    cSec1ModuleConfigData* getConfData();
 
+    cSec1Module* m_pModule; // the module we live in
     Zera::Server::cSECInterface* m_pSECInterface;
     Zera::Server::cPCBInterface* m_pPCBInterface;
 

--- a/zera-modules/sem1module/src/sem1module.cpp
+++ b/zera-modules/sem1module/src/sem1module.cpp
@@ -74,11 +74,8 @@ void cSem1Module::setupModule()
     emit addEventSystem(m_pModuleValidator);
     cBaseMeasModule::setupModule();
 
-    cSem1ModuleConfigData *pConfData;
-    pConfData = qobject_cast<cSem1ModuleConfiguration*>(m_pConfiguration.get())->getConfigurationData();
-
     // we only have this activist
-    m_pMeasProgram = new cSem1ModuleMeasProgram(this, m_pProxy, *pConfData);
+    m_pMeasProgram = new cSem1ModuleMeasProgram(this, m_pProxy, m_pConfiguration);
     m_ModuleActivistList.append(m_pMeasProgram);
     connect(m_pMeasProgram, SIGNAL(activated()), SIGNAL(activationContinue()));
     connect(m_pMeasProgram, SIGNAL(deactivated()), this, SIGNAL(deactivationContinue()));

--- a/zera-modules/sem1module/src/sem1modulemeasprogram.h
+++ b/zera-modules/sem1module/src/sem1modulemeasprogram.h
@@ -88,7 +88,7 @@ class cSem1ModuleMeasProgram: public cBaseMeasProgram
     Q_OBJECT
 
 public:
-    cSem1ModuleMeasProgram(cSem1Module* module, Zera::Proxy::cProxy* proxy, cSem1ModuleConfigData& configData);
+    cSem1ModuleMeasProgram(cSem1Module* module, Zera::Proxy::cProxy* proxy, std::shared_ptr<cBaseModuleConfiguration> pConfiguration);
     virtual ~cSem1ModuleMeasProgram();
     virtual void generateInterface(); // here we export our interface (entities)
     virtual void deleteInterface(); // we delete interface in case of reconfiguration
@@ -102,9 +102,9 @@ protected slots:
     virtual void catchInterfaceAnswer(quint32 msgnr, quint8 reply, QVariant answer);
 
 private:
-    cSem1Module* m_pModule; // the module we live in
-    cSem1ModuleConfigData& m_ConfigData;
+    cSem1ModuleConfigData* getConfData();
 
+    cSem1Module* m_pModule; // the module we live in
     Zera::Server::cSECInterface* m_pSECInterface;
     Zera::Server::cPCBInterface* m_pPCBInterface;
 

--- a/zera-modules/spm1module/src/spm1module.cpp
+++ b/zera-modules/spm1module/src/spm1module.cpp
@@ -74,11 +74,8 @@ void cSpm1Module::setupModule()
     emit addEventSystem(m_pModuleValidator);
     cBaseMeasModule::setupModule();
 
-    cSpm1ModuleConfigData *pConfData;
-    pConfData = qobject_cast<cSpm1ModuleConfiguration*>(m_pConfiguration.get())->getConfigurationData();
-
     // we only have this activist
-    m_pMeasProgram = new cSpm1ModuleMeasProgram(this, m_pProxy, *pConfData);
+    m_pMeasProgram = new cSpm1ModuleMeasProgram(this, m_pProxy, m_pConfiguration);
     m_ModuleActivistList.append(m_pMeasProgram);
     connect(m_pMeasProgram, SIGNAL(activated()), SIGNAL(activationContinue()));
     connect(m_pMeasProgram, SIGNAL(deactivated()), this, SIGNAL(deactivationContinue()));

--- a/zera-modules/spm1module/src/spm1modulemeasprogram.cpp
+++ b/zera-modules/spm1module/src/spm1modulemeasprogram.cpp
@@ -22,13 +22,14 @@
 #include "spm1module.h"
 #include "spm1modulemeasprogram.h"
 #include "spm1moduleconfigdata.h"
+#include "spm1moduleconfiguration.h"
 #include "unithelper.h"
 
 namespace SPM1MODULE
 {
 
-cSpm1ModuleMeasProgram::cSpm1ModuleMeasProgram(cSpm1Module* module, Zera::Proxy::cProxy* proxy, cSpm1ModuleConfigData& configData)
-    :cBaseMeasProgram(proxy), m_pModule(module), m_ConfigData(configData)
+cSpm1ModuleMeasProgram::cSpm1ModuleMeasProgram(cSpm1Module* module, Zera::Proxy::cProxy* proxy, std::shared_ptr<cBaseModuleConfiguration> pConfiguration)
+    :cBaseMeasProgram(proxy, pConfiguration), m_pModule(module)
 {
     // we have to instantiate a working resource manager and secserver interface
     m_pRMInterface = new Zera::Server::cRMInterface();
@@ -195,10 +196,10 @@ cSpm1ModuleMeasProgram::~cSpm1ModuleMeasProgram()
 {
     int n;
 
-    n = m_ConfigData.m_refInpList.count();
+    n = getConfData()->m_refInpList.count();
     for (int i = 0; i < n; i++)
     {
-        siInfo = mREFSpmInputInfoHash.take(m_ConfigData.m_refInpList.at(i));
+        siInfo = mREFSpmInputInfoHash.take(getConfData()->m_refInpList.at(i));
         delete siInfo;
     }
 
@@ -493,13 +494,13 @@ void cSpm1ModuleMeasProgram::catchInterfaceAnswer(quint32 msgnr, quint8 reply, Q
                 {
                     m_MasterEcalculator.name = sl.at(0);
                     m_MasterEcalculator.secIFace = m_pSECInterface;
-                    m_MasterEcalculator.secServersocket = m_ConfigData.m_SECServerSocket;
+                    m_MasterEcalculator.secServersocket = getConfData()->m_SECServerSocket;
                     m_SlaveEcalculator.name = sl.at(1);
                     m_SlaveEcalculator.secIFace = m_pSECInterface;
-                    m_SlaveEcalculator.secServersocket = m_ConfigData.m_SECServerSocket;
+                    m_SlaveEcalculator.secServersocket = getConfData()->m_SECServerSocket;
                     m_Slave2Ecalculator.name = sl.at(2);
                     m_Slave2Ecalculator.secIFace = m_pSECInterface;
-                    m_Slave2Ecalculator.secServersocket = m_ConfigData.m_SECServerSocket;
+                    m_Slave2Ecalculator.secServersocket = getConfData()->m_SECServerSocket;
                     emit activationContinue();
                 }
                 else
@@ -840,14 +841,19 @@ void cSpm1ModuleMeasProgram::catchInterfaceAnswer(quint32 msgnr, quint8 reply, Q
     }
 }
 
+cSpm1ModuleConfigData *cSpm1ModuleMeasProgram::getConfData()
+{
+    return qobject_cast<cSpm1ModuleConfiguration*>(m_pConfiguration.get())->getConfigurationData();
+}
+
 
 void cSpm1ModuleMeasProgram::setInterfaceComponents()
 {
-    m_pRefInputPar->setValue(QVariant(mREFSpmInputInfoHash[m_ConfigData.m_sRefInput.m_sPar]->alias));
-    m_pTargetedPar->setValue(QVariant(m_ConfigData.m_bTargeted.m_nActive));
-    m_pMeasTimePar->setValue(QVariant(m_ConfigData.m_nMeasTime.m_nPar));
-    m_pUpperLimitPar->setValue(QVariant(m_ConfigData.m_fUpperLimit.m_fPar));
-    m_pLowerLimitPar->setValue(QVariant(m_ConfigData.m_fLowerLimit.m_fPar));
+    m_pRefInputPar->setValue(QVariant(mREFSpmInputInfoHash[getConfData()->m_sRefInput.m_sPar]->alias));
+    m_pTargetedPar->setValue(QVariant(getConfData()->m_bTargeted.m_nActive));
+    m_pMeasTimePar->setValue(QVariant(getConfData()->m_nMeasTime.m_nPar));
+    m_pUpperLimitPar->setValue(QVariant(getConfData()->m_fUpperLimit.m_fPar));
+    m_pLowerLimitPar->setValue(QVariant(getConfData()->m_fLowerLimit.m_fPar));
 }
 
 
@@ -915,14 +921,14 @@ QStringList cSpm1ModuleMeasProgram::getPowerUnitValidator()
     QStringList sl;
     QString powType;
 
-    powType = mREFSpmInputInfoHash[m_ConfigData.m_sRefInput.m_sPar]->alias;
+    powType = mREFSpmInputInfoHash[getConfData()->m_sRefInput.m_sPar]->alias;
 
     if (powType.contains('P'))
-        sl = m_ConfigData.m_ActiveUnitList;
+        sl = getConfData()->m_ActiveUnitList;
     if (powType.contains('Q'))
-        sl = m_ConfigData.m_ReactiveUnitList;
+        sl = getConfData()->m_ReactiveUnitList;
     if (powType.contains('S'))
-        sl = m_ConfigData.m_ApparentUnitList;
+        sl = getConfData()->m_ApparentUnitList;
 
     return sl;
 }
@@ -930,7 +936,7 @@ QStringList cSpm1ModuleMeasProgram::getPowerUnitValidator()
 
 QString cSpm1ModuleMeasProgram::getPowerUnit()
 {
-    QString powerType = mREFSpmInputInfoHash[m_ConfigData.m_sRefInput.m_sPar]->alias;
+    QString powerType = mREFSpmInputInfoHash[getConfData()->m_sRefInput.m_sPar]->alias;
     QString currentPowerUnit = m_pInputUnitPar->getValue().toString();
 
     return cUnitHelper::getNewPowerUnit(powerType, currentPowerUnit);
@@ -940,7 +946,7 @@ QString cSpm1ModuleMeasProgram::getPowerUnit()
 void cSpm1ModuleMeasProgram::handleChangedREFConst()
 {
     // we ask for the reference constant of the selected Input
-    m_MsgNrCmdList[m_pPCBInterface->getConstantSource(m_ConfigData.m_sRefInput.m_sPar)] = fetchrefconstant;
+    m_MsgNrCmdList[m_pPCBInterface->getConstantSource(getConfData()->m_sRefInput.m_sPar)] = fetchrefconstant;
     stopMeasuerment(true);
 }
 
@@ -958,7 +964,7 @@ void cSpm1ModuleMeasProgram::handleSECInterrupt()
 void cSpm1ModuleMeasProgram::resourceManagerConnect()
 {
     // first we try to get a connection to resource manager over proxy
-    m_pRMClient = m_pProxy->getConnection(m_ConfigData.m_RMSocket.m_sIP, m_ConfigData.m_RMSocket.m_nPort);
+    m_pRMClient = m_pProxy->getConnection(getConfData()->m_RMSocket.m_sIP, getConfData()->m_RMSocket.m_nPort);
     // and then we set connection resource manager interface's connection
     m_pRMInterface->setClient(m_pRMClient); //
     resourceManagerConnectState.addTransition(m_pRMClient, SIGNAL(connected()), &m_IdentifyState);
@@ -992,13 +998,13 @@ void cSpm1ModuleMeasProgram::readResourceTypes()
     //m_MsgNrCmdList[m_pRMInterface->getResourceTypes()] = readresourcetypes;
     // instead of taking all resourcetypes we take predefined types if we found them in our config
 
-    if (found(m_ConfigData.m_refInpList, "fi"))
+    if (found(getConfData()->m_refInpList, "fi"))
         m_ResourceTypeList.append("FRQINPUT");
-    if (found(m_ConfigData.m_refInpList, "fo"))
+    if (found(getConfData()->m_refInpList, "fo"))
         m_ResourceTypeList.append("SOURCE");
-    if (found(m_ConfigData.m_refInpList, "sh"))
+    if (found(getConfData()->m_refInpList, "sh"))
         m_ResourceTypeList.append("SCHEAD");
-    if (found(m_ConfigData.m_refInpList, "hk"))
+    if (found(getConfData()->m_refInpList, "hk"))
         m_ResourceTypeList.append("HKEY");
 
     emit activationContinue();
@@ -1025,14 +1031,14 @@ void cSpm1ModuleMeasProgram::testSpmInputs()
     QList<QString> InputNameList;
     qint32 nref;
 
-    nref = m_ConfigData.m_refInpList.count();
+    nref = getConfData()->m_refInpList.count();
 
     // first we build up a list with properties for all configured Inputs
     for (int i = 0; i < nref; i++)
     {
-        // siInfo.muxchannel = m_ConfigData.m_refInpList.at(i).m_nMuxerCode;
+        // siInfo.muxchannel = getConfData()->m_refInpList.at(i).m_nMuxerCode;
         siInfo = new cSecInputInfo();
-        mREFSpmInputInfoHash[m_ConfigData.m_refInpList.at(i)] = siInfo;
+        mREFSpmInputInfoHash[getConfData()->m_refInpList.at(i)] = siInfo;
     }
 
     InputNameList = mREFSpmInputInfoHash.keys();
@@ -1076,7 +1082,7 @@ void cSpm1ModuleMeasProgram::testSpmInputs()
 void cSpm1ModuleMeasProgram::ecalcServerConnect()
 {
     // we try to get a connection to ecalc server over proxy
-    m_pSECClient = m_pProxy->getConnection(m_ConfigData.m_SECServerSocket.m_sIP, m_ConfigData.m_SECServerSocket.m_nPort);
+    m_pSECClient = m_pProxy->getConnection(getConfData()->m_SECServerSocket.m_sIP, getConfData()->m_SECServerSocket.m_nPort);
     // and then we set ecalcalculator interface's connection
     m_pSECInterface->setClient(m_pSECClient); //
     m_ecalcServerConnectState.addTransition(m_pSECClient, SIGNAL(connected()), &m_fetchECalcUnitsState);
@@ -1095,7 +1101,7 @@ void cSpm1ModuleMeasProgram::fetchECalcUnits()
 void cSpm1ModuleMeasProgram::pcbServerConnect()
 {
     // we try to get a connection to ecalc server over proxy
-    m_pPCBClient = m_pProxy->getConnection(m_ConfigData.m_PCBServerSocket.m_sIP, m_ConfigData.m_PCBServerSocket.m_nPort);
+    m_pPCBClient = m_pProxy->getConnection(getConfData()->m_PCBServerSocket.m_sIP, getConfData()->m_PCBServerSocket.m_nPort);
     // and then we set ecalcalculator interface's connection
     m_pPCBInterface->setClient(m_pPCBClient); //
     m_pcbServerConnectState.addTransition(m_pPCBClient, SIGNAL(connected()), &m_readREFInputsState);
@@ -1117,7 +1123,7 @@ void cSpm1ModuleMeasProgram::readREFInputAlias()
     m_sIt = m_sItList.takeFirst();
     siInfo = mREFSpmInputInfoHash.take(m_sIt); // if set some info that could be useful later
     siInfo->pcbIFace = m_pPCBInterface; // in case that Inputs would be provided by several servers
-    siInfo->pcbServersocket = m_ConfigData.m_PCBServerSocket;
+    siInfo->pcbServersocket = getConfData()->m_PCBServerSocket;
     //m_MsgNrCmdList[siInfo->pcbIFace->resourceAliasQuery(siInfo->resource, m_sIt)] = readrefInputalias;
 
     // we will read the powertype of the reference frequency input and will use this as our alias ! for example P, +P ....
@@ -1138,9 +1144,9 @@ void cSpm1ModuleMeasProgram::readREFInputDone()
 
 void cSpm1ModuleMeasProgram::setpcbREFConstantNotifier()
 {
-    if ( (m_ConfigData.m_nRefInpCount > 0) && m_ConfigData.m_bEmbedded ) // if we have some ref. Input and are embedded in meter we register for notification
+    if ( (getConfData()->m_nRefInpCount > 0) && getConfData()->m_bEmbedded ) // if we have some ref. Input and are embedded in meter we register for notification
     {
-        m_MsgNrCmdList[m_pPCBInterface->registerNotifier(QString("SOURCE:%1:CONSTANT?").arg(m_ConfigData.m_sRefInput.m_sPar),QString("%1").arg(irqPCBNotifier))] = setpcbrefconstantnotifier;
+        m_MsgNrCmdList[m_pPCBInterface->registerNotifier(QString("SOURCE:%1:CONSTANT?").arg(getConfData()->m_sRefInput.m_sPar),QString("%1").arg(irqPCBNotifier))] = setpcbrefconstantnotifier;
         // todo also configure the query for setting this notifier .....very flexible
     }
     else
@@ -1158,12 +1164,12 @@ void cSpm1ModuleMeasProgram::activationDone()
 {
     int nref;
 
-    nref = m_ConfigData.m_refInpList.count();
+    nref = getConfData()->m_refInpList.count();
     if (nref > 0)
     for (int i = 0; i < nref; i++)
     {
-        m_REFAliasList.append(mREFSpmInputInfoHash[m_ConfigData.m_refInpList.at(i)]->alias); // build up a fixed sorted list of alias
-        siInfo = mREFSpmInputInfoHash[m_ConfigData.m_refInpList.at(i)]; // change the hash for access via alias
+        m_REFAliasList.append(mREFSpmInputInfoHash[getConfData()->m_refInpList.at(i)]->alias); // build up a fixed sorted list of alias
+        siInfo = mREFSpmInputInfoHash[getConfData()->m_refInpList.at(i)]; // change the hash for access via alias
         mREFSpmInputSelectionHash[siInfo->alias] = siInfo;
     }
 
@@ -1185,7 +1191,7 @@ void cSpm1ModuleMeasProgram::activationDone()
     setUnits();
 
     // we ask for the reference constant of the selected Input
-    m_MsgNrCmdList[m_pPCBInterface->getConstantSource(m_ConfigData.m_sRefInput.m_sPar)] = fetchrefconstant;
+    m_MsgNrCmdList[m_pPCBInterface->getConstantSource(getConfData()->m_sRefInput.m_sPar)] = fetchrefconstant;
 
     m_bActive = true;
     emit activated();
@@ -1332,7 +1338,7 @@ void cSpm1ModuleMeasProgram::readTCountact()
 {
     m_MsgNrCmdList[m_pSECInterface->readRegister(m_Slave2Ecalculator.name, ECALCREG::MTCNTfin)] = readtcount;
     // non targeted has been stopped already in newStartStop()
-    if(m_ConfigData.m_bTargeted.m_nActive) {
+    if(getConfData()->m_bTargeted.m_nActive) {
         m_MsgNrCmdList[m_pSECInterface->stop(m_MasterEcalculator.name)] = stopmeas;
     }
     m_pStartStopPar->setValue(QVariant(0)); // restart enable
@@ -1377,7 +1383,7 @@ void cSpm1ModuleMeasProgram::setRating()
 {
     if (m_nStatus & ECALCSTATUS::READY)
     {
-        if ( (m_fResult >= m_ConfigData.m_fLowerLimit.m_fPar) && (m_fResult <= m_ConfigData.m_fUpperLimit.m_fPar))
+        if ( (m_fResult >= getConfData()->m_fLowerLimit.m_fPar) && (m_fResult <= getConfData()->m_fUpperLimit.m_fPar))
             m_eRating = ECALCRESULT::RESULT_PASSED;
         else
             m_eRating = ECALCRESULT::RESULT_FAILED;
@@ -1406,7 +1412,7 @@ void cSpm1ModuleMeasProgram::newStartStop(QVariant startstop)
     }
     else
     {
-        if (m_ConfigData.m_bTargeted.m_nActive > 0) {
+        if (getConfData()->m_bTargeted.m_nActive > 0) {
             stopMeasuerment(true);
         }
         else {
@@ -1433,7 +1439,7 @@ void cSpm1ModuleMeasProgram::newRefConstant(QVariant refconst)
 
 void cSpm1ModuleMeasProgram::newRefInput(QVariant refinput)
 {
-    m_ConfigData.m_sRefInput.m_sPar = mREFSpmInputSelectionHash[refinput.toString()]->name;
+    getConfData()->m_sRefInput.m_sPar = mREFSpmInputSelectionHash[refinput.toString()]->name;
     setInterfaceComponents();
     // if the reference input changes P <-> Q <-> S it is necessary to change energyunit and powerunit and their validators
 
@@ -1446,7 +1452,7 @@ void cSpm1ModuleMeasProgram::newRefInput(QVariant refinput)
 
 void cSpm1ModuleMeasProgram::newTargeted(QVariant targeted)
 {
-    m_ConfigData.m_bTargeted.m_nActive = targeted.toInt();
+    getConfData()->m_bTargeted.m_nActive = targeted.toInt();
     setInterfaceComponents();
 
     emit m_pModule->parameterChanged();
@@ -1455,7 +1461,7 @@ void cSpm1ModuleMeasProgram::newTargeted(QVariant targeted)
 
 void cSpm1ModuleMeasProgram::newMeasTime(QVariant meastime)
 {
-    m_ConfigData.m_nMeasTime.m_nPar = meastime.toInt();
+    getConfData()->m_nMeasTime.m_nPar = meastime.toInt();
     setInterfaceComponents();
 
     emit m_pModule->parameterChanged();
@@ -1493,7 +1499,7 @@ void cSpm1ModuleMeasProgram::newUnit(QVariant unit)
 void cSpm1ModuleMeasProgram::newUpperLimit(QVariant limit)
 {
     bool ok;
-    m_ConfigData.m_fUpperLimit.m_fPar = limit.toDouble(&ok);
+    getConfData()->m_fUpperLimit.m_fPar = limit.toDouble(&ok);
     setRating();
     setInterfaceComponents();
 
@@ -1504,7 +1510,7 @@ void cSpm1ModuleMeasProgram::newUpperLimit(QVariant limit)
 void cSpm1ModuleMeasProgram::newLowerLimit(QVariant limit)
 {
     bool ok;
-    m_ConfigData.m_fLowerLimit.m_fPar = limit.toDouble(&ok);
+    getConfData()->m_fLowerLimit.m_fPar = limit.toDouble(&ok);
     setRating();
     setInterfaceComponents();
 

--- a/zera-modules/spm1module/src/spm1modulemeasprogram.h
+++ b/zera-modules/spm1module/src/spm1modulemeasprogram.h
@@ -88,7 +88,7 @@ class cSpm1ModuleMeasProgram: public cBaseMeasProgram
     Q_OBJECT
 
 public:
-    cSpm1ModuleMeasProgram(cSpm1Module* module, Zera::Proxy::cProxy* proxy, cSpm1ModuleConfigData& configData);
+    cSpm1ModuleMeasProgram(cSpm1Module* module, Zera::Proxy::cProxy* proxy, std::shared_ptr<cBaseModuleConfiguration> pConfiguration);
     virtual ~cSpm1ModuleMeasProgram();
     virtual void generateInterface(); // here we export our interface (entities)
     virtual void deleteInterface(); // we delete interface in case of reconfiguration
@@ -102,9 +102,9 @@ protected slots:
     virtual void catchInterfaceAnswer(quint32 msgnr, quint8 reply, QVariant answer);
 
 private:
-    cSpm1Module* m_pModule; // the module we live in
-    cSpm1ModuleConfigData& m_ConfigData;
+    cSpm1ModuleConfigData* getConfData();
 
+    cSpm1Module* m_pModule; // the module we live in
     Zera::Server::cSECInterface* m_pSECInterface;
     Zera::Server::cPCBInterface* m_pPCBInterface;
 

--- a/zera-modules/thdnmodule/src/thdnmodule.cpp
+++ b/zera-modules/thdnmodule/src/thdnmodule.cpp
@@ -83,7 +83,7 @@ void cThdnModule::setupModule()
     pConfData = qobject_cast<cThdnModuleConfiguration*>(m_pConfiguration.get())->getConfigurationData();
 
     // we need some program that does the measuring on dsp
-    m_pMeasProgram = new cThdnModuleMeasProgram(this, m_pProxy, *pConfData);
+    m_pMeasProgram = new cThdnModuleMeasProgram(this, m_pProxy, m_pConfiguration);
     m_ModuleActivistList.append(m_pMeasProgram);
     connect(m_pMeasProgram, SIGNAL(activated()), SIGNAL(activationContinue()));
     connect(m_pMeasProgram, SIGNAL(deactivated()), this, SIGNAL(deactivationContinue()));

--- a/zera-modules/thdnmodule/src/thdnmodulemeasprogram.h
+++ b/zera-modules/thdnmodule/src/thdnmodulemeasprogram.h
@@ -67,7 +67,7 @@ class cThdnModuleMeasProgram: public cBaseDspMeasProgram
     Q_OBJECT
 
 public:
-    cThdnModuleMeasProgram(cThdnModule* module, Zera::Proxy::cProxy* proxy, cThdnModuleConfigData& configdata);
+    cThdnModuleMeasProgram(cThdnModule* module, Zera::Proxy::cProxy* proxy, std::shared_ptr<cBaseModuleConfiguration> pConfiguration);
     virtual ~cThdnModuleMeasProgram();
     virtual void generateInterface(); // here we export our interface (entities)
     virtual void deleteInterface(); // we delete interface in case of reconfiguration
@@ -86,9 +86,9 @@ protected slots:
     virtual void catchInterfaceAnswer(quint32 msgnr, quint8 reply, QVariant answer);
 
 private:
-    cThdnModule* m_pModule;
-    cThdnModuleConfigData& m_ConfigData;
+    cThdnModuleConfigData* getConfData();
 
+    cThdnModule* m_pModule;
     QList<cVeinModuleActvalue*> m_ActValueList; // the list of actual values we work on
     cVeinModuleMetaData* m_pThdnCountInfo;
     cVeinModuleComponent* m_pMeasureSignal;

--- a/zera-modules/transformer1module/src/transformer1module.cpp
+++ b/zera-modules/transformer1module/src/transformer1module.cpp
@@ -79,11 +79,8 @@ void cTransformer1Module::setupModule()
 
     cBaseMeasModule::setupModule();
 
-    cTransformer1ModuleConfigData* pConfData;
-    pConfData = qobject_cast<cTransformer1ModuleConfiguration*>(m_pConfiguration.get())->getConfigurationData();
-
     // we need some program that does the measuring on dsp
-    m_pMeasProgram = new cTransformer1ModuleMeasProgram(this, *pConfData);
+    m_pMeasProgram = new cTransformer1ModuleMeasProgram(this, m_pConfiguration);
     m_ModuleActivistList.append(m_pMeasProgram);
     connect(m_pMeasProgram, SIGNAL(activated()), SIGNAL(activationContinue()));
     connect(m_pMeasProgram, SIGNAL(deactivated()), this, SIGNAL(deactivationContinue()));

--- a/zera-modules/transformer1module/src/transformer1modulemeasprogram.cpp
+++ b/zera-modules/transformer1module/src/transformer1modulemeasprogram.cpp
@@ -20,13 +20,14 @@
 #include "transformer1module.h"
 #include "transformer1modulemeasprogram.h"
 #include "transformer1measdelegate.h"
+#include "transformer1moduleconfiguration.h"
 
 
 namespace TRANSFORMER1MODULE
 {
 
-cTransformer1ModuleMeasProgram::cTransformer1ModuleMeasProgram(cTransformer1Module* module, cTransformer1ModuleConfigData& configdata)
-    :m_pModule(module), m_ConfigData(configdata)
+cTransformer1ModuleMeasProgram::cTransformer1ModuleMeasProgram(cTransformer1Module* module, std::shared_ptr<cBaseModuleConfiguration> pConfiguration)
+    :cBaseMeasWorkProgram(pConfiguration), m_pModule(module)
 {
     m_searchActualValuesState.addTransition(this, SIGNAL(activationContinue()), &m_activationDoneState);
 
@@ -68,6 +69,11 @@ void cTransformer1ModuleMeasProgram::stop()
     disconnect(this, SIGNAL(actualValues(QVector<float>*)), this, 0);
 }
 
+cTransformer1ModuleConfigData *cTransformer1ModuleMeasProgram::getConfData()
+{
+    return qobject_cast<cTransformer1ModuleConfiguration*>(m_pConfiguration.get())->getConfigurationData();
+}
+
 
 void cTransformer1ModuleMeasProgram::generateInterface()
 {
@@ -75,7 +81,7 @@ void cTransformer1ModuleMeasProgram::generateInterface()
     cSCPIInfo* pSCPIInfo;
     QString key, s;
 
-    for (int i = 0; i < m_ConfigData.m_nTransformerSystemCount; i++)
+    for (int i = 0; i < getConfData()->m_nTransformerSystemCount; i++)
     {
         pActvalue = new cVeinModuleActvalue(m_pModule->m_nEntityId, m_pModule->m_pModuleValidator,
                                             QString("ACT_Error%1").arg(i+1),
@@ -121,7 +127,7 @@ void cTransformer1ModuleMeasProgram::generateInterface()
                                             QString("Component forwards reference N secondary input"),
                                             QVariant(0.0) );
         pActvalue->setChannelName(QString("INSEC%1").arg(i+1));
-        pActvalue->setUnit(QString(m_ConfigData.m_clampUnit[0]));
+        pActvalue->setUnit(QString(getConfData()->m_clampUnit[0]));
 
         pSCPIInfo = new cSCPIInfo("MEASURE", pActvalue->getChannelName(), "8", pActvalue->getName(), "0", pActvalue->getUnit());
         pActvalue->setSCPIInfo(pSCPIInfo);
@@ -134,7 +140,7 @@ void cTransformer1ModuleMeasProgram::generateInterface()
                                             QString("Component forwards decive under test secondary input"),
                                             QVariant(0.0) );
         pActvalue->setChannelName(QString("IXSEC%1").arg(i+1));
-        pActvalue->setUnit(QString(m_ConfigData.m_clampUnit[2]));
+        pActvalue->setUnit(QString(getConfData()->m_clampUnit[2]));
 
         pSCPIInfo = new cSCPIInfo("MEASURE", pActvalue->getChannelName(), "8", pActvalue->getName(), "0", pActvalue->getUnit());
         pActvalue->setSCPIInfo(pSCPIInfo);
@@ -147,7 +153,7 @@ void cTransformer1ModuleMeasProgram::generateInterface()
                                             QString("Component forwards decive under test primary input"),
                                             QVariant(0.0) );
         pActvalue->setChannelName(QString("IXPRIM%1").arg(i+1));
-        pActvalue->setUnit(QString(m_ConfigData.m_clampUnit[4]));
+        pActvalue->setUnit(QString(getConfData()->m_clampUnit[4]));
 
         pSCPIInfo = new cSCPIInfo("MEASURE", pActvalue->getChannelName(), "8", pActvalue->getName(), "0", pActvalue->getUnit());
         pActvalue->setSCPIInfo(pSCPIInfo);
@@ -159,8 +165,8 @@ void cTransformer1ModuleMeasProgram::generateInterface()
     m_pPrimClampPrimParameter = new cVeinModuleParameter(m_pModule->m_nEntityId, m_pModule->m_pModuleValidator,
                                                          key = QString("PAR_PrimClampPrim"),
                                                          QString("Component for setting the modules primary clamp primary value"),
-                                                         QVariant(m_ConfigData.primClampPrim.m_fValue));
-    s = QString(m_ConfigData.m_clampUnit[0]);
+                                                         QVariant(getConfData()->primClampPrim.m_fValue));
+    s = QString(getConfData()->m_clampUnit[0]);
     m_pPrimClampPrimParameter->setUnit(s);
     m_pPrimClampPrimParameter->setSCPIInfo(new cSCPIInfo("CONFIGURATION","PCPRIMARY", "10", "PAR_PrimClampPrim", "0", s));
 
@@ -173,8 +179,8 @@ void cTransformer1ModuleMeasProgram::generateInterface()
     m_pPrimClampSecParameter = new cVeinModuleParameter(m_pModule->m_nEntityId, m_pModule->m_pModuleValidator,
                                                         key = QString("PAR_PrimClampSec"),
                                                         QString("Component for setting the modules primary clamp secondary value"),
-                                                        QVariant(m_ConfigData.primClampSec.m_fValue));
-    s = QString(m_ConfigData.m_clampUnit[1]);
+                                                        QVariant(getConfData()->primClampSec.m_fValue));
+    s = QString(getConfData()->m_clampUnit[1]);
     m_pPrimClampSecParameter->setUnit(s);
     m_pPrimClampSecParameter->setSCPIInfo(new cSCPIInfo("CONFIGURATION","PCSECONDARY", "10", "PAR_PrimClampSec", "0", s));
 
@@ -186,8 +192,8 @@ void cTransformer1ModuleMeasProgram::generateInterface()
     m_pSecClampPrimParameter = new cVeinModuleParameter(m_pModule->m_nEntityId, m_pModule->m_pModuleValidator,
                                                         key = QString("PAR_SecClampPrim"),
                                                         QString("Component for setting the modules secondary clamp primary value"),
-                                                        QVariant(m_ConfigData.secClampPrim.m_fValue));
-    s = QString(m_ConfigData.m_clampUnit[2]);
+                                                        QVariant(getConfData()->secClampPrim.m_fValue));
+    s = QString(getConfData()->m_clampUnit[2]);
     m_pSecClampPrimParameter->setUnit(s);
     m_pSecClampPrimParameter->setSCPIInfo(new cSCPIInfo("CONFIGURATION","SCPRIMARY", "10", "PAR_SecClampPrim", "0", s));
 
@@ -199,8 +205,8 @@ void cTransformer1ModuleMeasProgram::generateInterface()
     m_pSecClampSecParameter = new cVeinModuleParameter(m_pModule->m_nEntityId, m_pModule->m_pModuleValidator,
                                                        key = QString("PAR_SecClampSec"),
                                                        QString("Component for setting the modules secondary clamp secondary value"),
-                                                       QVariant(m_ConfigData.secClampSec.m_fValue));
-    s = QString(m_ConfigData.m_clampUnit[3]);
+                                                       QVariant(getConfData()->secClampSec.m_fValue));
+    s = QString(getConfData()->m_clampUnit[3]);
     m_pSecClampSecParameter->setUnit(s);
     m_pSecClampSecParameter->setSCPIInfo(new cSCPIInfo("CONFIGURATION","SCSECONDARY", "10", "PAR_SecClampSec", "0", s));
 
@@ -212,8 +218,8 @@ void cTransformer1ModuleMeasProgram::generateInterface()
     m_pPrimDutParameter = new cVeinModuleParameter(m_pModule->m_nEntityId, m_pModule->m_pModuleValidator,
                                                    key = QString("PAR_DutPrimary"),
                                                    QString("Component for setting the modules dut primary value"),
-                                                   QVariant(m_ConfigData.dutPrim.m_fValue));
-    s = QString(m_ConfigData.m_clampUnit[4]);
+                                                   QVariant(getConfData()->dutPrim.m_fValue));
+    s = QString(getConfData()->m_clampUnit[4]);
     m_pPrimDutParameter->setUnit(s);
     m_pPrimDutParameter->setSCPIInfo(new cSCPIInfo("CONFIGURATION","DUTPRIMARY", "10", "PAR_DutPrimary", "0", s));
 
@@ -225,8 +231,8 @@ void cTransformer1ModuleMeasProgram::generateInterface()
     m_pSecDutParameter = new cVeinModuleParameter(m_pModule->m_nEntityId, m_pModule->m_pModuleValidator,
                                                   key = QString("PAR_DutSecondary"),
                                                   QString("Component for setting the modules dut secondary value"),
-                                                  QVariant(m_ConfigData.dutSec.m_fValue));
-    s = QString(m_ConfigData.m_clampUnit[5]);
+                                                  QVariant(getConfData()->dutSec.m_fValue));
+    s = QString(getConfData()->m_clampUnit[5]);
     m_pSecDutParameter->setUnit(s);
     m_pSecDutParameter->setSCPIInfo(new cSCPIInfo("CONFIGURATION","DUTSECONDARY", "10", "PAR_DutSecondary", "0", s));
 
@@ -235,7 +241,7 @@ void cTransformer1ModuleMeasProgram::generateInterface()
 
     m_pModule->veinModuleParameterHash[key] = m_pSecDutParameter; // for modules use
 
-    m_pTRSCountInfo = new cVeinModuleMetaData(QString("TRSCount"), QVariant(m_ConfigData.m_nTransformerSystemCount));
+    m_pTRSCountInfo = new cVeinModuleMetaData(QString("TRSCount"), QVariant(getConfData()->m_nTransformerSystemCount));
     m_pModule->veinModuleMetaDataList.append(m_pTRSCountInfo);
 
     m_pMeasureSignal = new cVeinModuleComponent(m_pModule->m_nEntityId, m_pModule->m_pModuleValidator,
@@ -259,16 +265,16 @@ void cTransformer1ModuleMeasProgram::searchActualValues()
     error = false;
     QList<cVeinModuleComponentInput*> inputList;
 
-    for (int i = 0; i < m_ConfigData.m_nTransformerSystemCount; i++)
+    for (int i = 0; i < getConfData()->m_nTransformerSystemCount; i++)
     {
         // we first test that wanted input components exist
-        if ( (m_pModule->m_pStorageSystem->hasStoredValue(m_ConfigData.m_nModuleId, m_ConfigData.m_transformerSystemConfigList.at(i).m_sInputPrimaryVector)) &&
-             (m_pModule->m_pStorageSystem->hasStoredValue(m_ConfigData.m_nModuleId, m_ConfigData.m_transformerSystemConfigList.at(i).m_sInputSecondaryVector)) )
+        if ( (m_pModule->m_pStorageSystem->hasStoredValue(getConfData()->m_nModuleId, getConfData()->m_transformerSystemConfigList.at(i).m_sInputPrimaryVector)) &&
+             (m_pModule->m_pStorageSystem->hasStoredValue(getConfData()->m_nModuleId, getConfData()->m_transformerSystemConfigList.at(i).m_sInputSecondaryVector)) )
         {
             cTransformer1MeasDelegate *cTMD;
             cVeinModuleComponentInput *vmci;
 
-            if (i == (m_ConfigData.m_nTransformerSystemCount-1))
+            if (i == (getConfData()->m_nTransformerSystemCount-1))
             {
                 cTMD = new cTransformer1MeasDelegate(m_ActValueList.at(i*6), m_ActValueList.at(i*6+1), m_ActValueList.at(i*6+2),
                                                      m_ActValueList.at(i*6+3), m_ActValueList.at(i*6+4), m_ActValueList.at(i*6+5), true);
@@ -280,11 +286,11 @@ void cTransformer1ModuleMeasProgram::searchActualValues()
 
             m_Transformer1MeasDelegateList.append(cTMD);
 
-            vmci = new cVeinModuleComponentInput(m_ConfigData.m_nModuleId, m_ConfigData.m_transformerSystemConfigList.at(i).m_sInputPrimaryVector);
+            vmci = new cVeinModuleComponentInput(getConfData()->m_nModuleId, getConfData()->m_transformerSystemConfigList.at(i).m_sInputPrimaryVector);
             inputList.append(vmci);
             connect(vmci, SIGNAL(sigValueChanged(QVariant)), cTMD, SLOT(actValueInput1(QVariant)));
 
-            vmci = new cVeinModuleComponentInput(m_ConfigData.m_nModuleId, m_ConfigData.m_transformerSystemConfigList.at(i).m_sInputSecondaryVector);
+            vmci = new cVeinModuleComponentInput(getConfData()->m_nModuleId, getConfData()->m_transformerSystemConfigList.at(i).m_sInputSecondaryVector);
             inputList.append(vmci);
             connect(vmci, SIGNAL(sigValueChanged(QVariant)), cTMD, SLOT(actValueInput2(QVariant)));
         }
@@ -345,7 +351,7 @@ void cTransformer1ModuleMeasProgram::setMeasureSignal(int signal)
 void cTransformer1ModuleMeasProgram::newPrimClampPrim(QVariant pcp)
 {
     bool ok;
-    m_ConfigData.primClampPrim.m_fValue = pcp.toFloat(&ok);
+    getConfData()->primClampPrim.m_fValue = pcp.toFloat(&ok);
     setParameters();
 
     emit m_pModule->parameterChanged();
@@ -355,7 +361,7 @@ void cTransformer1ModuleMeasProgram::newPrimClampPrim(QVariant pcp)
 void cTransformer1ModuleMeasProgram::newPrimClampSec(QVariant pcs)
 {
     bool ok;
-    m_ConfigData.primClampSec.m_fValue = pcs.toFloat(&ok);
+    getConfData()->primClampSec.m_fValue = pcs.toFloat(&ok);
     setParameters();
 
     emit m_pModule->parameterChanged();
@@ -365,7 +371,7 @@ void cTransformer1ModuleMeasProgram::newPrimClampSec(QVariant pcs)
 void cTransformer1ModuleMeasProgram::newSecClampPrim(QVariant scp)
 {
     bool ok;
-    m_ConfigData.secClampPrim.m_fValue = scp.toFloat(&ok);
+    getConfData()->secClampPrim.m_fValue = scp.toFloat(&ok);
     setParameters();
 
     emit m_pModule->parameterChanged();
@@ -375,7 +381,7 @@ void cTransformer1ModuleMeasProgram::newSecClampPrim(QVariant scp)
 void cTransformer1ModuleMeasProgram::newSecClampSec(QVariant scs)
 {
     bool ok;
-    m_ConfigData.secClampSec.m_fValue = scs.toFloat(&ok);
+    getConfData()->secClampSec.m_fValue = scs.toFloat(&ok);
     setParameters();
 
     emit m_pModule->parameterChanged();
@@ -385,7 +391,7 @@ void cTransformer1ModuleMeasProgram::newSecClampSec(QVariant scs)
 void cTransformer1ModuleMeasProgram::newPrimDut(QVariant pd)
 {
     bool ok;
-    m_ConfigData.dutPrim.m_fValue = pd.toFloat(&ok);
+    getConfData()->dutPrim.m_fValue = pd.toFloat(&ok);
     setParameters();
 
     emit m_pModule->parameterChanged();
@@ -395,7 +401,7 @@ void cTransformer1ModuleMeasProgram::newPrimDut(QVariant pd)
 void cTransformer1ModuleMeasProgram::newSecDut(QVariant sd)
 {
     bool ok;
-    m_ConfigData.dutSec.m_fValue = sd.toFloat(&ok);
+    getConfData()->dutSec.m_fValue = sd.toFloat(&ok);
     setParameters();
 
     emit m_pModule->parameterChanged();
@@ -408,12 +414,12 @@ void cTransformer1ModuleMeasProgram::setParameters()
     for (int i = 0; i < m_Transformer1MeasDelegateList.count(); i++)
     {
         cTransformer1MeasDelegate* tmd = m_Transformer1MeasDelegateList.at(i);
-        tmd->setPrimClampPrim(m_ConfigData.primClampPrim.m_fValue);
-        tmd->setPrimClampSec(m_ConfigData.primClampSec.m_fValue);
-        tmd->setSecClampPrim(m_ConfigData.secClampPrim.m_fValue);
-        tmd->setSecClampSec(m_ConfigData.secClampSec.m_fValue);
-        tmd->setDutPrim(m_ConfigData.dutPrim.m_fValue);
-        tmd->setDutSec(m_ConfigData.dutSec.m_fValue);
+        tmd->setPrimClampPrim(getConfData()->primClampPrim.m_fValue);
+        tmd->setPrimClampSec(getConfData()->primClampSec.m_fValue);
+        tmd->setSecClampPrim(getConfData()->secClampPrim.m_fValue);
+        tmd->setSecClampSec(getConfData()->secClampSec.m_fValue);
+        tmd->setDutPrim(getConfData()->dutPrim.m_fValue);
+        tmd->setDutSec(getConfData()->dutSec.m_fValue);
     }
 }
 

--- a/zera-modules/transformer1module/src/transformer1modulemeasprogram.h
+++ b/zera-modules/transformer1module/src/transformer1modulemeasprogram.h
@@ -83,7 +83,7 @@ class cTransformer1ModuleMeasProgram: public cBaseMeasWorkProgram
     Q_OBJECT
 
 public:
-    cTransformer1ModuleMeasProgram(cTransformer1Module* module, cTransformer1ModuleConfigData& configdata);
+    cTransformer1ModuleMeasProgram(cTransformer1Module* module, std::shared_ptr<cBaseModuleConfiguration> pConfiguration);
     virtual ~cTransformer1ModuleMeasProgram();
     virtual void generateInterface(); // here we export our interface (entities)
     virtual void deleteInterface(); // we delete interface in case of reconfiguration
@@ -93,9 +93,9 @@ public slots:
     virtual void stop(); // in interface are not updated when stop
 
 private:
-    cTransformer1Module* m_pModule;
-    cTransformer1ModuleConfigData& m_ConfigData;
+    cTransformer1ModuleConfigData* getConfData();
 
+    cTransformer1Module* m_pModule;
     QList<cVeinModuleActvalue*> m_ActValueList; // the list of actual values we work on
     cVeinModuleMetaData* m_pTRSCountInfo; // the number of transformer system we are configured for
     cVeinModuleComponent* m_pMeasureSignal;


### PR DESCRIPTION
Instead of accessing config data by an unsafe reference, use shared pointer to
configurations in meas programs.

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>