### PR TITLE
sourcemodule: Let FG4PhaseTest support harmonics

### DIFF
--- a/zera-modules/sourcemodule/deviceinfo/FG4PhaseTest.json
+++ b/zera-modules/sourcemodule/deviceinfo/FG4PhaseTest.json
@@ -8,7 +8,7 @@
   "U1": {
     "minVal": 0.001,
     "maxVal": 300.0,
-    "supportsHarmonics": false
+    "supportsHarmonics": true
   },
   "U2": {
     "sameAs": "U1"
@@ -23,7 +23,7 @@
   "I1": {
     "minVal": 0.001,
     "maxVal": 20.0,
-    "supportsHarmonics": false
+    "supportsHarmonics": true
   },
   "I2": {
     "sameAs": "I1"


### PR DESCRIPTION
As the name suggests FG4PhaseTest is for test only and has no real life
device. To allow GUI testing as long as there is no harmonics support, allow
harmonics only here.

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>