### PR TITLE
Make unittest start properly on CI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,7 +90,11 @@ if(ZC_BUILD_MODULES)
     endforeach()
 endif(ZC_BUILD_MODULES)
 
-
+find_package(GTest)
+if(${GTest_FOUND})
+    message(STATUS "building with unittest")
+    enable_testing()
+endif()
 
 
 

--- a/zera-modules/sourcemodule/CMakeLists.txt
+++ b/zera-modules/sourcemodule/CMakeLists.txt
@@ -172,7 +172,7 @@ install(
 
 find_package(GTest)
 if(${GTest_FOUND})
-    message(STATUS "building with unittest")
+    message(STATUS "unittest sourcemodule")
     enable_testing()
 
     add_test(NAME    sourcemodule-unittest


### PR DESCRIPTION
We have to enable tests in topmost CMake - otherwise they are not started by CI

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>