### PR TITLE
Wip improve code

### DIFF
--- a/zera-modules/sourcemodule/src/sourceiopacketgenerator.cpp
+++ b/zera-modules/sourcemodule/src/sourceiopacketgenerator.cpp
@@ -104,8 +104,8 @@ tSourceOutInList cSourceIoPacketGenerator::generateRMSAndAngleUList()
     double rmsU[3], angleU[3] = {0.0, 0.0, 0.0};
     for(int phase=0; phase<3; phase++) {
         if(phase < m_jsonStructApi->getCountUPhases()) {
-            rmsU[phase] = m_paramsRequested.getRms(true, phase);
-            angleU[phase] = m_paramsRequested.getAngle(true, phase);
+            rmsU[phase] = m_paramsRequested.getRms(phaseType::U, phase);
+            angleU[phase] = m_paramsRequested.getAngle(phaseType::U, phase);
         }
     }
 
@@ -133,8 +133,8 @@ tSourceOutInList cSourceIoPacketGenerator::generateRMSAndAngleIList()
     double rmsI[3], angleI[3] = {0.0, 0.0, 0.0};
     for(int phase=0; phase<3; phase++) {
         if(phase < m_jsonStructApi->getCountIPhases()) {
-            rmsI[phase] = m_paramsRequested.getRms(false, phase);
-            angleI[phase] = m_paramsRequested.getAngle(false, phase);
+            rmsI[phase] = m_paramsRequested.getRms(phaseType::I, phase);
+            angleI[phase] = m_paramsRequested.getAngle(phaseType::I, phase);
         }
     }
 
@@ -168,7 +168,7 @@ tSourceOutInList cSourceIoPacketGenerator::generateSwitchPhasesList()
         bool phaseAvail = phase < phaseCountU;
         bPhaseOn = false;
         if(globalOn && phaseAvail) {
-            bPhaseOn = m_paramsRequested.getOn(true, phase);
+            bPhaseOn = m_paramsRequested.getOn(phaseType::U, phase);
         }
         bytesSend.append(bPhaseOn ? "E" : "A");
     }
@@ -177,20 +177,20 @@ tSourceOutInList cSourceIoPacketGenerator::generateSwitchPhasesList()
         bool phaseAvail = phase < phaseCountI;
         bPhaseOn = false;
         if(globalOn && phaseAvail) {
-            bPhaseOn = m_paramsRequested.getOn(false, phase);
+            bPhaseOn = m_paramsRequested.getOn(phaseType::I, phase);
         }
         bytesSend.append(bPhaseOn ? "P" : "A");
     }
     // aux u
     bPhaseOn = false;
     if(globalOn && phaseCountU>3) {
-        bPhaseOn = m_paramsRequested.getOn(true, 3);
+        bPhaseOn = m_paramsRequested.getOn(phaseType::U, 3);
     }
     bytesSend.append(bPhaseOn ? "E" : "A");
     // aux i
     bPhaseOn = false;
     if(globalOn && phaseCountI>3) {
-        bPhaseOn = m_paramsRequested.getOn(false, 3);
+        bPhaseOn = m_paramsRequested.getOn(phaseType::I, 3);
     }
     bytesSend.append(bPhaseOn ? "E" : "A");
     // relative comparison - off for now

--- a/zera-modules/sourcemodule/src/sourcejsonapi.cpp
+++ b/zera-modules/sourcemodule/src/sourcejsonapi.cpp
@@ -44,21 +44,21 @@ void cSourceJsonParamApi::setOn(bool on)
     m_params["on"] = on;
 }
 
-double cSourceJsonParamApi::getRms(bool u, int phaseIdxBase0)
+double cSourceJsonParamApi::getRms(phaseType type, int phaseIdxBase0)
 {
-    QString phaseName = getPhaseName(u, phaseIdxBase0);
+    QString phaseName = getPhaseName(type, phaseIdxBase0);
     return m_params[phaseName].toObject()["rms"].toDouble(0.0);
 }
 
-double cSourceJsonParamApi::getAngle(bool u, int phaseIdxBase0)
+double cSourceJsonParamApi::getAngle(phaseType type, int phaseIdxBase0)
 {
-    QString phaseName = getPhaseName(u, phaseIdxBase0);
+    QString phaseName = getPhaseName(type, phaseIdxBase0);
     return m_params[phaseName].toObject()["angle"].toDouble(0.0);
 }
 
-bool cSourceJsonParamApi::getOn(bool u, int phaseIdxBase0)
+bool cSourceJsonParamApi::getOn(phaseType type, int phaseIdxBase0)
 {
-    QString phaseName = getPhaseName(u, phaseIdxBase0);
+    QString phaseName = getPhaseName(type, phaseIdxBase0);
     QJsonObject obj = m_params[phaseName].toObject();
     return obj.contains("on") && obj["on"].toBool();
 }
@@ -73,7 +73,12 @@ double cSourceJsonParamApi::getFreqVal()
     return m_params["Frequency"].toObject()["val"].toDouble();
 }
 
-QString cSourceJsonParamApi::getPhaseName(bool u, int phaseIdxBase0)
+QString cSourceJsonParamApi::getPhaseName(phaseType type, int phaseIdxBase0)
 {
-    return QString("%1%2").arg(u ? "U" : "I").arg(phaseIdxBase0+1);
+    if(type == phaseType::U){
+        return QString("%1%2").arg("U").arg(phaseIdxBase0+1);
+    }else if(type == phaseType::I){
+        return QString("%1%2").arg("I").arg(phaseIdxBase0+1);
+    }
+    return QString();
 }

--- a/zera-modules/sourcemodule/src/sourcejsonapi.h
+++ b/zera-modules/sourcemodule/src/sourcejsonapi.h
@@ -15,6 +15,12 @@ private:
     QJsonObject m_paramStructure;
 };
 
+
+enum class phaseType{
+    U, //Voltage
+    I  //Current
+};
+
 class cSourceJsonParamApi
 {
 public:
@@ -26,14 +32,14 @@ public:
     bool getOn();
     void setOn(bool on);
 
-    double getRms(bool u, int phaseIdxBase0);
-    double getAngle(bool u, int phaseIdxBase0);
-    bool getOn(bool u, int phaseIdxBase0);
+    double getRms(phaseType type, int phaseIdxBase0);
+    double getAngle(phaseType type, int phaseIdxBase0);
+    bool getOn(phaseType type, int phaseIdxBase0);
 
     bool getFreqVarOn();
     double getFreqVal();
 private:
-    QString getPhaseName(bool u, int phaseIdxBase0);
+    QString getPhaseName(phaseType type, int phaseIdxBase0);
 
     QJsonObject m_params;
 };

--- a/zera-modules/sourcemodule/tests/unittest-sourceactions.cpp
+++ b/zera-modules/sourcemodule/tests/unittest-sourceactions.cpp
@@ -29,14 +29,31 @@ TEST(TEST_SOURCEACTIONS, SWITCH_ON_COMPLETE) {
     EXPECT_EQ(actionList.count(), cSourceActionTypes::switchTypeCount);
 }
 
+template<class T> bool elementIsIn(T ele, std::vector<T> list){
+    if(list.empty()){
+        return false;
+    }
+    if(std::find(begin(list),end(list),ele) != list.end()){
+        return true;
+    }else{
+        return false;
+    }
+}
+
 // Check for switch on all valid
 TEST(TEST_SOURCEACTIONS, SWITCH_ON_VALID) {
     cSourceJsonParamApi paramApi;
     paramApi.setOn(true);
     tSourceActionTypeList actionList = cSourceActionGenerator::generateSwitchActions(cSourceJsonParamApi(paramApi));
     for(auto action : actionList) {
-        EXPECT_GT(action, cSourceActionTypes::SWITCH_UNDEF);
-        EXPECT_LT(action, cSourceActionTypes::SWITCH_UNDEF2);
+        EXPECT_TRUE(elementIsIn<cSourceActionTypes::ActionTypes>(action,{
+                                                                     cSourceActionTypes::SET_RMS,
+                                                                     cSourceActionTypes::SET_ANGLE,
+                                                                     cSourceActionTypes::SET_FREQUENCY,
+                                                                     cSourceActionTypes::SET_HARMONICS,
+                                                                     cSourceActionTypes::SET_REGULATOR,
+                                                                     cSourceActionTypes::SWITCH_PHASES
+                                                                 }));
         EXPECT_TRUE(cSourceActionTypes::isValidType(action));
     }
 }
@@ -56,8 +73,14 @@ TEST(TEST_SOURCEACTIONS, SWITCH_OFF_VALID) {
     paramApi.setOn(false);
     tSourceActionTypeList actionList = cSourceActionGenerator::generateSwitchActions(cSourceJsonParamApi(paramApi));
     for(auto action : actionList) {
-        EXPECT_GT(action, cSourceActionTypes::SWITCH_UNDEF);
-        EXPECT_LT(action, cSourceActionTypes::SWITCH_UNDEF2);
+        EXPECT_TRUE(elementIsIn<cSourceActionTypes::ActionTypes>(action,{
+                                                                     cSourceActionTypes::SET_RMS,
+                                                                     cSourceActionTypes::SET_ANGLE,
+                                                                     cSourceActionTypes::SET_FREQUENCY,
+                                                                     cSourceActionTypes::SET_HARMONICS,
+                                                                     cSourceActionTypes::SET_REGULATOR,
+                                                                     cSourceActionTypes::SWITCH_PHASES
+                                                                 }));
         EXPECT_TRUE(cSourceActionTypes::isValidType(action));
     }
 }
@@ -65,8 +88,10 @@ TEST(TEST_SOURCEACTIONS, SWITCH_OFF_VALID) {
 TEST(TEST_SOURCEACTIONS, PERIODIC_VALID) {
     tSourceActionTypeList actionList = cSourceActionGenerator::generatePeriodicActions();
     for(auto action : actionList) {
-        EXPECT_GT(action, cSourceActionTypes::PERIODIC_UNDEF);
-        EXPECT_LT(action, cSourceActionTypes::PERIODIC_UNDEF2);
+        EXPECT_TRUE(elementIsIn<cSourceActionTypes::ActionTypes>(action,{
+                                                                     cSourceActionTypes::QUERY_STATUS,
+                                                                     cSourceActionTypes::QUERY_ACTUAL
+                                                                 }));
         EXPECT_TRUE(cSourceActionTypes::isValidType(action));
     }
 }

--- a/zera-modules/sourcemodule/tests/unittest-sourcejsonapi.cpp
+++ b/zera-modules/sourcemodule/tests/unittest-sourcejsonapi.cpp
@@ -141,9 +141,9 @@ TEST(TEST_SOURCE_PARAM_API, GETTER_RMS) {
     };
     cSourceJsonParamApi paramApi;
     paramApi.setParams(testParams);
-    EXPECT_DOUBLE_EQ(paramApi.getRms(true, 0), 1.1);
-    EXPECT_DOUBLE_EQ(paramApi.getRms(true, 1), 2.2);
-    EXPECT_DOUBLE_EQ(paramApi.getRms(false, 2), 3.3);
+    EXPECT_DOUBLE_EQ(paramApi.getRms(phaseType::U, 0), 1.1);
+    EXPECT_DOUBLE_EQ(paramApi.getRms(phaseType::U, 1), 2.2);
+    EXPECT_DOUBLE_EQ(paramApi.getRms(phaseType::I, 2), 3.3);
 }
 
 TEST(TEST_SOURCE_PARAM_API, GETTER_ANGLE) {
@@ -158,9 +158,9 @@ TEST(TEST_SOURCE_PARAM_API, GETTER_ANGLE) {
     };
     cSourceJsonParamApi paramApi;
     paramApi.setParams(testParams);
-    EXPECT_DOUBLE_EQ(paramApi.getAngle(true, 0), 0.1);
-    EXPECT_DOUBLE_EQ(paramApi.getAngle(true, 1), 0.2);
-    EXPECT_DOUBLE_EQ(paramApi.getAngle(false, 2), 0.3);
+    EXPECT_DOUBLE_EQ(paramApi.getAngle(phaseType::U, 0), 0.1);
+    EXPECT_DOUBLE_EQ(paramApi.getAngle(phaseType::U, 1), 0.2);
+    EXPECT_DOUBLE_EQ(paramApi.getAngle(phaseType::I, 2), 0.3);
 }
 
 TEST(TEST_SOURCE_PARAM_API, GETTER_PHASE_ON) {
@@ -175,9 +175,9 @@ TEST(TEST_SOURCE_PARAM_API, GETTER_PHASE_ON) {
     };
     cSourceJsonParamApi paramApi;
     paramApi.setParams(testParams);
-    EXPECT_EQ(paramApi.getOn(true, 0), false);
-    EXPECT_EQ(paramApi.getOn(true, 1), true);
-    EXPECT_EQ(paramApi.getOn(false, 2), false);
+    EXPECT_EQ(paramApi.getOn(phaseType::U, 0), false);
+    EXPECT_EQ(paramApi.getOn(phaseType::U, 1), true);
+    EXPECT_EQ(paramApi.getOn(phaseType::I, 2), false);
 }
 
 TEST(TEST_SOURCE_PARAM_API, GETTER_FREQ_VAR) {


### PR DESCRIPTION
Take a look at the code. I think the first commit makes a lot of sense.
The second is my personal taste not to use operators other than == ,!=, =
on enums, because I consider them to be pure symbolic variables and not
comparable in size. Furthermore, adding an additional value could break something,
but would not be caught by the unit-test.

**Please note: I was not able to test this on device or in any other way. The only thing I did was run the unit-tests.**