### PR TITLE
sourceinterface: increase default response timeout

### DIFF
--- a/zera-modules/sourcemodule/src/sourceinterface.h
+++ b/zera-modules/sourcemodule/src/sourceinterface.h
@@ -7,7 +7,7 @@
 #include <QTimer>
 #include "sourceidgenerator.h"
 
-static constexpr int sourceDefaultTimeout = 1000;
+static constexpr int sourceDefaultTimeout = 1500;
 
 enum SourceInterfaceTypes
 {


### PR DESCRIPTION
This make MT500 play well

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>