### PR TITLE
Remove debug level from all i2c related classes to simplify code

### DIFF
--- a/zera-comm/zera-i2c/i2cutils.cpp
+++ b/zera-comm/zera-i2c/i2cutils.cpp
@@ -7,45 +7,33 @@
 
 #include "i2cutils.h"
 
-int I2CTransfer(QString deviceNode,int i2cadr, int debugLevel, i2c_rdwr_ioctl_data* iodata)
+int I2CTransfer(QString deviceNode, int i2cadr, i2c_rdwr_ioctl_data* iodata)
 {
     int fd;
     if ( (fd = open(deviceNode.toLatin1().data(),O_RDWR)) < 0 ) {
-        if (debugLevel & 1) {
-            syslog(LOG_ERR,"error opening i2c device: %s / open() error: %i / %s\n",
-                   deviceNode.toLatin1().data(), errno, strerror(errno));
-        }
+        syslog(LOG_ERR,"error opening i2c device: %s / open() error: %i / %s\n",
+               deviceNode.toLatin1().data(), errno, strerror(errno));
         return(1); // error connection
     }
     if (ioctl(fd,I2C_RETRIES,0) < 0) {
         close(fd);
-        if (debugLevel & 1) {
-            syslog(LOG_ERR,"error setting retries of i2c device: %s / ioctl(fd,I2C_RETRIES,0) error: %i / %s\n",
-                   deviceNode.toLatin1().data(), errno, strerror(errno));
-        }
+        syslog(LOG_ERR,"error setting retries of i2c device: %s / ioctl(fd,I2C_RETRIES,0) error: %i / %s\n",
+               deviceNode.toLatin1().data(), errno, strerror(errno));
         return(1); // error connection
     }
     if (ioctl(fd,I2C_TIMEOUT,500) < 0) {
         close(fd);
-        if (debugLevel & 1) {
-            syslog(LOG_ERR,"error setting retries of i2c device: %s / ioctl(fd,I2C_TIMEOUT,500) error: %i / %s\n",
-                   deviceNode.toLatin1().data(), errno, strerror(errno));
-        }
+        syslog(LOG_ERR,"error setting retries of i2c device: %s / ioctl(fd,I2C_TIMEOUT,500) error: %i / %s\n",
+               deviceNode.toLatin1().data(), errno, strerror(errno));
         return(1); // error connection
     }
     if (ioctl(fd,I2C_RDWR,iodata) < 0) {
-        if (debugLevel & 1) {
-            syslog(LOG_ERR,"error read/write i2c slave at adress: 0x%02X / ioctl(fd,I2C_RDWR,iodata) error: %i / %s\n",
-                   i2cadr, errno, strerror(errno));
-        }
+        syslog(LOG_ERR,"error read/write i2c slave at adress: 0x%02X / ioctl(fd,I2C_RDWR,iodata) error: %i / %s\n",
+               i2cadr, errno, strerror(errno));
         close(fd);
         return(2); // error device
     }
 
-    if (debugLevel & 2) {
-        syslog(LOG_INFO,"read/write i2c slave at adress: 0x%02X done\n",
-               i2cadr);
-    }
     close(fd);
     return(0); // acknowledge
 }

--- a/zera-comm/zera-i2c/i2cutils.h
+++ b/zera-comm/zera-i2c/i2cutils.h
@@ -14,9 +14,8 @@
 
   @param[in] deviceNode is full path i2c device node /dev/i2c-3/0 for example
   @param[in] i2cadr is sent debug information if desired
-  @param[in] debugLevel decides what to write to syslog
   */
-int ZERAI2C_EXPORT I2CTransfer( QString deviceNode, int i2cadr, int debugLevel, i2c_rdwr_ioctl_data* iodata);
+int ZERAI2C_EXPORT I2CTransfer( QString deviceNode, int i2cadr, i2c_rdwr_ioctl_data* iodata);
 
 
 #endif // I2CUTILS_H

--- a/zera-dev/F24LC256.cpp
+++ b/zera-dev/F24LC256.cpp
@@ -1,8 +1,8 @@
 #include "F24LC256.h"
 #include "F24LC256_p.h"
 
-cF24LC256::cF24LC256(QString devNode, int dLevel, short adr)
-    :d_ptr( new cF24LC256Private(devNode, dLevel, adr))
+cF24LC256::cF24LC256(QString devNode, short adr)
+    :d_ptr( new cF24LC256Private(devNode, adr))
 {
 }
 

--- a/zera-dev/F24LC256.h
+++ b/zera-dev/F24LC256.h
@@ -9,7 +9,7 @@ class cF24LC256Private;
 class ZERADEV_EXPORT cF24LC256: public cI2CEEPromPrivate
 {
 public:
-    cF24LC256(QString devNode,int dLevel,short adr);
+    cF24LC256(QString devNode, short adr);
     virtual ~cF24LC256();
     virtual int WriteData(char* data, ushort count, ushort adr);
     virtual int ReadData(char* data, ushort count, ushort adr);

--- a/zera-dev/F24LC256_p.cpp
+++ b/zera-dev/F24LC256_p.cpp
@@ -11,8 +11,8 @@
 #include "F24LC256_p.h"
 
 
-cF24LC256Private::cF24LC256Private(QString devNode, int dLevel, short adr)
-    : cI2CEEPromPrivate(devNode,dLevel,adr)
+cF24LC256Private::cF24LC256Private(QString devNode, short adr)
+    : cI2CEEPromPrivate(devNode, adr)
 {
 }
 
@@ -24,7 +24,7 @@ int cF24LC256Private::WriteData(char* data, ushort count, ushort adr)
     struct i2c_rdwr_ioctl_data EEPromData = { msgs: &(Msgs), nmsgs: 1 };
     int toWrite = count;
 
-    if ( I2CTransfer(DevNode,I2CAdress,DebugLevel,&EEPromData) )
+    if ( I2CTransfer(DevNode, I2CAdress, &EEPromData) )
     return 0; // we couldn't write any data
 
     Msgs.flags = 0; // switch to write direction
@@ -41,7 +41,7 @@ int cF24LC256Private::WriteData(char* data, ushort count, ushort adr)
         int r;
         for (int i = 0; i < 100; i++) // max 10ms
         {
-            if (( r = I2CTransfer(DevNode,I2CAdress,DebugLevel,&EEPromData)) == 0)
+            if (( r = I2CTransfer(DevNode, I2CAdress, &EEPromData)) == 0)
                 break;
             usleep(100);
         }
@@ -78,7 +78,7 @@ int cF24LC256Private::ReadData(char* data,ushort n,ushort adr)
         outpBuf[0]=(adr >> 8) & 0xff; outpBuf[1]=adr & 0xff; // we set the adress for the next transfer
         Msgs[1].len = l; // and it's length
 
-        if ( I2CTransfer(DevNode,I2CAdress,DebugLevel,&EEPromData) == 0 ) // alles ok und gelesen
+        if ( I2CTransfer(DevNode, I2CAdress, &EEPromData) == 0 ) // alles ok und gelesen
         {
             memcpy((void*)data,(void*)&inpBuf[0],l);
             adr += l;

--- a/zera-dev/F24LC256_p.h
+++ b/zera-dev/F24LC256_p.h
@@ -14,7 +14,7 @@
 class cF24LC256Private: public cI2CEEPromPrivate
 {
 public:
-    cF24LC256Private(QString devNode,int dLevel,short adr);
+    cF24LC256Private(QString devNode, short adr);
     virtual ~cF24LC256Private(){};
     virtual int WriteData(char* data, ushort count, ushort adr) override;
     virtual int ReadData(char* data, ushort count, ushort adr) override;

--- a/zera-dev/i2ceeprom_p.cpp
+++ b/zera-dev/i2ceeprom_p.cpp
@@ -1,6 +1,6 @@
 #include "i2ceeprom_p.h"
 
-cI2CEEPromPrivate::cI2CEEPromPrivate(QString dNode, int dLevel, ushort adr)
-    :DevNode(dNode), DebugLevel(dLevel), I2CAdress(adr)
+cI2CEEPromPrivate::cI2CEEPromPrivate(QString dNode, ushort adr)
+    :DevNode(dNode), I2CAdress(adr)
 {
 }

--- a/zera-dev/i2ceeprom_p.h
+++ b/zera-dev/i2ceeprom_p.h
@@ -18,7 +18,7 @@ public:
       @param[in] d(ebug)Level decides what to write to syslog
       @param[in] (i2c)adr is the devices adress
       */
-    cI2CEEPromPrivate(QString dNode, int dLevel, ushort adr);
+    cI2CEEPromPrivate(QString dNode, ushort adr);
     cI2CEEPromPrivate(){};
     virtual ~cI2CEEPromPrivate(){};
 
@@ -43,7 +43,6 @@ public:
     virtual int size()=0;
 protected:
     QString DevNode;
-    int DebugLevel;
     ushort I2CAdress;
 };
 

--- a/zera-dev/zera_mcontroller_base.cpp
+++ b/zera-dev/zera_mcontroller_base.cpp
@@ -127,7 +127,7 @@ quint16 ZeraMcontrollerBase::writeCommand(hw_cmd * hc, quint8 *dataReceive, quin
                m_nI2CAdr, hc->cmdcode, hc->device, qPrintable(i2cHexParam), dataAndCrcLen);
     }
 
-    int errVal = I2CTransfer(m_sI2CDevNode, m_nI2CAdr, m_nDebugLevel, &comData);
+    int errVal = I2CTransfer(m_sI2CDevNode, m_nI2CAdr, &comData);
     if (!errVal) { // if no error
         // Checksum OK?
         quint8 expectedCrc = cMaxim1WireCRC::CalcBlockCRC(inpBuf, 4);
@@ -227,7 +227,7 @@ quint16 ZeraMcontrollerBase::writeBootloaderCommand(bl_cmd* blc, quint8 *dataRec
                m_nI2CAdr, blc->cmdcode, qPrintable(i2cHexParam), dataAndCrcLen);
     }
 
-    int errVal = I2CTransfer(m_sI2CDevNode, m_nI2CAdr, m_nDebugLevel, &comData);
+    int errVal = I2CTransfer(m_sI2CDevNode, m_nI2CAdr, &comData);
     if (!errVal) { // no error?
         // Checksum OK?
         quint8 expectedCrc = cMaxim1WireCRC::CalcBlockCRC(inpBuf, 4);
@@ -332,7 +332,7 @@ quint16 ZeraMcontrollerBase::readOutput(quint8 *data, quint16 dataAndCrcLen)
         syslog(LOG_INFO,"i2c read start: adr 0x%02X / len %u",
                 m_nI2CAdr, dataAndCrcLen);
     }
-    int errVal = I2CTransfer(m_sI2CDevNode, m_nI2CAdr, m_nDebugLevel, &comData);
+    int errVal = I2CTransfer(m_sI2CDevNode, m_nI2CAdr, &comData);
     if (!errVal) { // if no error
         QString i2cHexData;
         quint16 iByte;


### PR DESCRIPTION
* output errors unconditionally
* remove info message - logging is client's job

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>