### PR TITLE
Add new library zerameaschannels / add cJustNode

### DIFF
--- a/.github/workflows/buildAndTest.yml
+++ b/.github/workflows/buildAndTest.yml
@@ -9,6 +9,11 @@ jobs:
   build:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'ci skip')"
+    strategy:
+      matrix:
+        compiler:
+          - gcc
+          - clang
 
     container:
       image: schnitzeltony/fedora-qt5:32
@@ -30,6 +35,12 @@ jobs:
           cd $HOME
           mkdir -p "$HOME/targetbuild"
           cd "$HOME/targetbuild"
+
+          if [ "${{ matrix.compiler }}" == "clang" ]; then
+            export CC=clang
+            export CXX=clang++
+          fi
+
           cmake $GITHUB_WORKSPACE \
            -DCMAKE_PREFIX_PATH="$HOME/install/usr;/usr" \
            -DCMAKE_INSTALL_PREFIX:PATH="$HOME/install/usr" \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,7 @@ set(SUB_DIRS
     zera-comm
     zera-i2c
     zera-misc
+    zera-service-common
 )
 
 set(MODULE_DIRS

--- a/zera-service-common/CMakeLists.txt
+++ b/zera-service-common/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(src)

--- a/zera-service-common/src/CMakeLists.txt
+++ b/zera-service-common/src/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(meas-channels)

--- a/zera-service-common/src/meas-channels/CMakeLists.txt
+++ b/zera-service-common/src/meas-channels/CMakeLists.txt
@@ -1,0 +1,68 @@
+set(HEADER
+    justnode.h
+    )
+
+add_library(zerameaschannels SHARED
+    ${HEADER}
+    justnode.cpp
+    )
+
+target_link_libraries(zerameaschannels
+    PUBLIC
+    Qt5::Core
+    # ask linker to help us finding unresolved symbols
+    "-Wl,--no-undefined"
+    )
+
+# announce headers - target perspective
+target_include_directories(zerameaschannels
+    PUBLIC
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}/zera-classes/zerameaschannels>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    )
+
+set_target_properties(zerameaschannels PROPERTIES VERSION ${PROJECT_VERSION})
+set_target_properties(zerameaschannels PROPERTIES SOVERSION ${PROJECT_VERSION_MAJOR})
+
+generate_export_header(zerameaschannels)
+
+install(FILES
+    ${CMAKE_CURRENT_BINARY_DIR}/zerameaschannels_export.h
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/zera-classes/zerameaschannels
+    )
+
+install(TARGETS zerameaschannels
+    EXPORT zerameaschannelsExport
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    )
+
+# configure *ConfigVersion.cmake
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file(
+    zerameaschannelsConfigVersion.cmake
+    VERSION ${PACKAGE_VERSION}
+    COMPATIBILITY SameMajorVersion
+    )
+
+# configure *Config.cmake
+configure_file(zerameaschannelsConfig.cmake.in zerameaschannelsConfig.cmake @ONLY)
+
+# install *Config(Version).cmake
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/zerameaschannelsConfig.cmake"
+    "${CMAKE_CURRENT_BINARY_DIR}/zerameaschannelsConfigVersion.cmake"
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/zerameaschannels
+    )
+
+# install targets cmake-files
+install(EXPORT zerameaschannelsExport
+    FILE zerameaschannelsTargets.cmake
+    NAMESPACE ZeraClasses::
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/zerameaschannels
+    )
+
+# install public headers
+install(
+    FILES ${HEADER}
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/zera-classes/zerameaschannels
+    )

--- a/zera-service-common/src/meas-channels/justnode.cpp
+++ b/zera-service-common/src/meas-channels/justnode.cpp
@@ -1,0 +1,70 @@
+#include <QDataStream>
+#include <QString>
+
+#include "justnode.h"
+
+
+cJustNode::cJustNode(double corr, double arg)
+    :m_fCorrection(corr),m_fArgument(arg)
+{
+}
+
+
+void cJustNode::Serialize(QDataStream& qds)
+{
+    qds << m_fCorrection << m_fArgument;
+}
+
+
+void cJustNode::Deserialize(QDataStream& qds)
+{
+    qds >> m_fCorrection >> m_fArgument;
+}
+
+
+QString cJustNode::Serialize(int digits)
+{
+    QString s;
+    s = QString("%1;%2;").arg(m_fCorrection,0,'f',digits)
+                           .arg(m_fArgument,0,'f',digits);
+    return s;
+}
+
+
+void cJustNode::Deserialize(const QString& s)
+{
+    m_fCorrection = s.section( ';',0,0).toDouble();
+    m_fArgument = s.section( ';',1,1).toDouble();
+}
+
+
+cJustNode& cJustNode::operator = (const cJustNode& jn)
+{
+    m_fCorrection = jn.m_fCorrection;
+    m_fArgument = jn.m_fArgument;
+    return (*this);
+}
+
+
+void cJustNode::setCorrection(double value)
+{
+    m_fCorrection = value;
+}
+
+double cJustNode::getCorrection()
+{
+    return m_fCorrection;
+}
+
+
+void cJustNode::setArgument(double value)
+{
+   m_fArgument = value;
+}
+
+
+double cJustNode::getArgument()
+{
+    return m_fArgument;
+}
+

--- a/zera-service-common/src/meas-channels/justnode.h
+++ b/zera-service-common/src/meas-channels/justnode.h
@@ -1,0 +1,30 @@
+#ifndef JUSTNODE_H
+#define JUSTNODE_H
+
+#include <QDataStream>
+#include <QString>
+
+// an adjustmentnode (datapoint) consists of the data point's value and the data point's argument
+// it can serialize and deserialize itself to a qdatastream
+
+class cJustNode { // stützspunkt kann sich serialisieren und besteht aus stützwert (correction) und argument
+public:
+    cJustNode(double corr, double arg);
+    cJustNode(){};
+    ~cJustNode(){};
+    void Serialize(QDataStream&);
+    void Deserialize(QDataStream&);
+    QString Serialize(int digits);
+    void Deserialize(const QString&);
+    cJustNode& operator = (const cJustNode&);
+    void setCorrection(double value);
+    double getCorrection();
+    void setArgument(double value);
+    double getArgument();
+
+private:
+    double m_fCorrection;
+    double m_fArgument;
+};
+
+#endif // JUSTNODE_H

--- a/zera-service-common/src/meas-channels/zerameaschannelsConfig.cmake.in
+++ b/zera-service-common/src/meas-channels/zerameaschannelsConfig.cmake.in
@@ -1,0 +1,9 @@
+include(CMakeFindDependencyMacro)
+
+# dependencies
+find_dependency(Qt5 COMPONENTS Core CONFIG REQUIRED)
+find_dependency(zerai2c)
+
+# targets file
+include("${CMAKE_CURRENT_LIST_DIR}/zerameaschannelsTargets.cmake")
+


### PR DESCRIPTION
We take cJustNode from com5003d and mt310s2d with one modification:
cJustNode::Serialize gets a parameter digits. We have to pass this since

* mt310s2d serializes with 6 digits
* com5003d serializes with 8 digits

and we do not want to introduce incompatibilities

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>