### PR TITLE
scpimodule: Avoid double deletion on module unload

### DIFF
--- a/zera-modules/scpimodule/src/scpiserver.cpp
+++ b/zera-modules/scpimodule/src/scpiserver.cpp
@@ -222,14 +222,14 @@ void cSCPIServer::activationDone()
 
 void cSCPIServer::shutdownTCPServer()
 {
+    if (m_bSerialScpiActive) {
+        destroySerialScpi();
+    }
     for(auto client : m_SCPIClientList) {
         delete client;
     }
     m_SCPIClientList.clear();
     m_pTcpServer->close();
-    if (m_bSerialScpiActive) {
-        destroySerialScpi();
-    }
     emit deactivationContinue();
 }
 


### PR DESCRIPTION
m_pSerialClient is in m_SCPIClientList -> We have to call special delete before
deleting all from m_SCPIClientList.

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>