### PR TITLE
sourcemodule/qtest: replace QTest::qWait by QCoreApplication::process…

### DIFF
--- a/zera-modules-common/zera-basemodule/veinmodulecomponent.cpp
+++ b/zera-modules-common/zera-basemodule/veinmodulecomponent.cpp
@@ -45,7 +45,7 @@ void cVeinModuleComponent::setUnit(QString unit)
     m_sChannelUnit = unit;
 }
 
-const QVariant& cVeinModuleComponent::getValue() const
+QVariant cVeinModuleComponent::getValue()
 {
     return m_vValue;
 }

--- a/zera-modules-common/zera-basemodule/veinmodulecomponent.h
+++ b/zera-modules-common/zera-basemodule/veinmodulecomponent.h
@@ -15,7 +15,7 @@ public:
     void setChannelName(QString name); // channel name for json export can be empty
     QString getChannelName();
     void setUnit(QString unit);
-    const QVariant& getValue() const;
+    QVariant getValue();
     QString getUnit();
     QString getName();
 signals:

--- a/zera-modules/sourcemodule/tests/qtest/test_iodevice.cpp
+++ b/zera-modules/sourcemodule/tests/qtest/test_iodevice.cpp
@@ -143,15 +143,15 @@ void test_iodevice::demoResponseList()
 
     m_ioDataForSingleUse = IoTransferDataSingle::Ptr::create("", "0");
     ioDevice->sendAndReceive(m_ioDataForSingleUse);
-    QTest::qWait(shortQtEventTimeout); // one I/O at a time
+    QCoreApplication::processEvents(); // one I/O at a time
 
     m_ioDataForSingleUse = IoTransferDataSingle::Ptr::create("", "1");
     ioDevice->sendAndReceive(m_ioDataForSingleUse);
-    QTest::qWait(shortQtEventTimeout);
+    QCoreApplication::processEvents();
 
     m_ioDataForSingleUse = IoTransferDataSingle::Ptr::create("", "2");
     ioDevice->sendAndReceive(m_ioDataForSingleUse);
-    QTest::qWait(shortQtEventTimeout);
+    QCoreApplication::processEvents();
 
     QCOMPARE(m_ioFinishReceiveCount, 3);
     QCOMPARE(m_listReceivedData[0], "0\r");
@@ -232,13 +232,13 @@ void test_iodevice::demoDelayFollowsDelay()
     // huge timeout must be ignored
     m_ioDataForSingleUse = IoTransferDataSingle::Ptr::create("", "\r", "", 5000);
     ioDevice->sendAndReceive(m_ioDataForSingleUse);
-    QTest::qWait(shortQtEventTimeout);
+    QCoreApplication::processEvents();
     QCOMPARE(m_ioFinishReceiveCount, 1);
 
     demoIoDevice->setResponseDelay(false, 5000);
     m_ioDataForSingleUse = IoTransferDataSingle::Ptr::create("", "");
     ioDevice->sendAndReceive(m_ioDataForSingleUse);
-    QTest::qWait(shortQtEventTimeout);
+    QCoreApplication::processEvents();
 
     QCOMPARE(m_ioFinishReceiveCount, 1);
 }
@@ -251,12 +251,12 @@ void test_iodevice::demoDelayFollowsTimeout()
     m_ioDataForSingleUse = IoTransferDataSingle::Ptr::create("", "\r", "", 0);
     demoIoDevice->setResponseDelay(true, 5000 /* must be ignored */);
     ioDevice->sendAndReceive(m_ioDataForSingleUse);
-    QTest::qWait(shortQtEventTimeout);
+    QCoreApplication::processEvents();
     QCOMPARE(m_ioFinishReceiveCount, 1);
 
     m_ioDataForSingleUse = IoTransferDataSingle::Ptr::create("", "\r", "", 5000);
     ioDevice->sendAndReceive(m_ioDataForSingleUse);
-    QTest::qWait(shortQtEventTimeout);
+    QCoreApplication::processEvents();
     QCOMPARE(m_ioFinishReceiveCount, 1);
 }
 
@@ -302,7 +302,7 @@ void test_iodevice::checkNotifications(IoDeviceBase::Ptr ioDevice, int total, in
     ioDevice->sendAndReceive(dummyIoData);
     QCOMPARE(m_ioFinishReceiveCount, 0); // check for queued
     QCOMPARE(m_errorsReceived, 0);
-    QTest::qWait(shortQtEventTimeout);
+    QCoreApplication::processEvents();
     QCOMPARE(m_ioFinishReceiveCount, total);
     QCOMPARE(m_errorsReceived, errors);
 }

--- a/zera-modules/sourcemodule/tests/qtest/test_iotransferdata.cpp
+++ b/zera-modules/sourcemodule/tests/qtest/test_iotransferdata.cpp
@@ -102,7 +102,7 @@ void test_iotransferdata::singleCheckUsedDataDataReceived()
     IoTransferDataSingle::Ptr ioTransferData = IoTransferDataSingle::Ptr::create("", "");
     IoDeviceBase::Ptr ioDevice = createOpenDemoIoDevice();
     ioDevice->sendAndReceive(ioTransferData);
-    QTest::qWait(shortQtEventTimeout);
+    QCoreApplication::processEvents();
     QCOMPARE(ioTransferData->wasNotRunYet(), false);
 }
 
@@ -111,7 +111,7 @@ void test_iotransferdata::singleCheckUsedDataNoAnswer()
     IoTransferDataSingle::Ptr ioTransferData = IoTransferDataSingle::Ptr::create("", "", "");
     IoDeviceBase::Ptr ioDevice = createOpenDemoIoDevice();
     ioDevice->sendAndReceive(ioTransferData);
-    QTest::qWait(shortQtEventTimeout);
+    QCoreApplication::processEvents();
     QVERIFY(ioTransferData->noAnswerReceived());
     QCOMPARE(ioTransferData->wasNotRunYet(), false);
 }
@@ -122,7 +122,7 @@ void test_iotransferdata::singleCheckUsedWrongAnswer()
     ioTransferData->getDemoResponder()->activateErrorResponse();
     IoDeviceBase::Ptr ioDevice = createOpenDemoIoDevice();
     ioDevice->sendAndReceive(ioTransferData);
-    QTest::qWait(shortQtEventTimeout);
+    QCoreApplication::processEvents();
     QVERIFY(ioTransferData->wrongAnswerReceived());
     QCOMPARE(ioTransferData->wasNotRunYet(), false);
 }
@@ -132,7 +132,7 @@ void test_iotransferdata::singleCheckUsedPass()
     IoTransferDataSingle::Ptr ioTransferData = IoTransferDataSingle::Ptr::create("fooSend", "fooLead", "fooTrail");
     IoDeviceBase::Ptr ioDevice = createOpenDemoIoDevice();
     ioDevice->sendAndReceive(ioTransferData);
-    QTest::qWait(shortQtEventTimeout);
+    QCoreApplication::processEvents();
     QVERIFY(ioTransferData->didIoPass());
     QCOMPARE(ioTransferData->wasNotRunYet(), false);
 }
@@ -146,7 +146,7 @@ void test_iotransferdata::singleCheckInjectSingleExpected()
     ioTransferData->getDemoResponder()->overrideDefaultResponse(overrideResponse);
     IoDeviceBase::Ptr ioDevice = createOpenDemoIoDevice();
     ioDevice->sendAndReceive(ioTransferData);
-    QTest::qWait(shortQtEventTimeout);
+    QCoreApplication::processEvents();
     QVERIFY(ioTransferData->didIoPass());
     QCOMPARE(ioTransferData->getBytesReceived(), overrideResponse);
 }
@@ -163,7 +163,7 @@ void test_iotransferdata::singleCheckInjectMultipleExpected()
     QByteArray overrideResponse = lead1+"foo"+trail;
     ioTransferData1->getDemoResponder()->overrideDefaultResponse(overrideResponse);
     ioDevice->sendAndReceive(ioTransferData1);
-    QTest::qWait(shortQtEventTimeout);
+    QCoreApplication::processEvents();
     QVERIFY(ioTransferData1->didIoPass());
     QCOMPARE(ioTransferData1->getBytesReceived(), overrideResponse);
 
@@ -173,7 +173,7 @@ void test_iotransferdata::singleCheckInjectMultipleExpected()
     ioTransferData2->getDemoResponder()->overrideDefaultResponse(overrideResponse);
     ioDevice->sendAndReceive(ioTransferData2);
 
-    QTest::qWait(shortQtEventTimeout);
+    QCoreApplication::processEvents();
     QVERIFY(ioTransferData2->didIoPass());
     QCOMPARE(ioTransferData2->getBytesReceived(), overrideResponse);
 }
@@ -217,7 +217,7 @@ void test_iotransferdata::singleDataEvalNoAnswer()
     IoTransferDataSingle::Ptr ioTransferData = IoTransferDataSingle::Ptr::create("", "", "");
     IoDeviceBase::Ptr ioDevice = createOpenDemoIoDevice();
     ioDevice->sendAndReceive(ioTransferData);
-    QTest::qWait(shortQtEventTimeout);
+    QCoreApplication::processEvents();
     QVERIFY(ioTransferData->noAnswerReceived());
 }
 
@@ -227,7 +227,7 @@ void test_iotransferdata::singleDataEvalWrongAnswerConstruct1()
     ioTransferData->getDemoResponder()->activateErrorResponse();
     IoDeviceBase::Ptr ioDevice = createOpenDemoIoDevice();
     ioDevice->sendAndReceive(ioTransferData);
-    QTest::qWait(shortQtEventTimeout);
+    QCoreApplication::processEvents();
     QVERIFY(ioTransferData->wrongAnswerReceived());
 }
 
@@ -239,7 +239,7 @@ void test_iotransferdata::singleDataEvalWrongAnswerConstruct2()
     ioTransferData->getDemoResponder()->activateErrorResponse();
     IoDeviceBase::Ptr ioDevice = createOpenDemoIoDevice();
     ioDevice->sendAndReceive(ioTransferData);
-    QTest::qWait(shortQtEventTimeout);
+    QCoreApplication::processEvents();
     QVERIFY(ioTransferData->wrongAnswerReceived());
 }
 
@@ -248,7 +248,7 @@ void test_iotransferdata::singleDataEvalPassConstruct1()
     IoTransferDataSingle::Ptr ioTransferData = IoTransferDataSingle::Ptr::create("fooSend", "fooLead", "fooTrail");
     IoDeviceBase::Ptr ioDevice = createOpenDemoIoDevice();
     ioDevice->sendAndReceive(ioTransferData);
-    QTest::qWait(shortQtEventTimeout);
+    QCoreApplication::processEvents();
     QVERIFY(ioTransferData->didIoPass());
 }
 
@@ -259,7 +259,7 @@ void test_iotransferdata::singleDataEvalPassConstruct2()
                                                                                  "fooTrail");
     IoDeviceBase::Ptr ioDevice = createOpenDemoIoDevice();
     ioDevice->sendAndReceive(ioTransferData);
-    QTest::qWait(shortQtEventTimeout);
+    QCoreApplication::processEvents();
     QVERIFY(ioTransferData->didIoPass());
 }
 

--- a/zera-modules/sourcemodule/tests/qtest/test_sourcedevicefacade.cpp
+++ b/zera-modules/sourcemodule/tests/qtest/test_sourcedevicefacade.cpp
@@ -90,7 +90,7 @@ void test_sourcedevicefacade::checkVeinInitialStatus()
     SourceDeviceFacade sourceFacade(ioDevice, DefaultTestSourceProperties());
     sourceFacade.setVeinInterface(&vein.veinInterface);
 
-    QTest::qWait(shortQtEventTimeout);
+    QCoreApplication::processEvents();
     QJsonObject jsonStatusVein = vein.veinActDeviceState.getValue().toJsonObject();
     JsonDeviceStatusApi statusApi;
     statusApi.setDeviceInfo(deviceInfo);
@@ -119,7 +119,7 @@ void test_sourcedevicefacade::checkVeinInitialInfo()
     SourceDeviceFacade sourceFacade(ioDevice, DefaultTestSourceProperties());
     sourceFacade.setVeinInterface(&vein.veinInterface);
 
-    QTest::qWait(shortQtEventTimeout);
+    QCoreApplication::processEvents();
     QJsonObject jsonStructInfo = vein.veinActDeviceInfo.getValue().toJsonObject();
     QCOMPARE(jsonStructInfo, jsonStructure);
     QCOMPARE(infosReceived.count(), 1);
@@ -145,7 +145,7 @@ void test_sourcedevicefacade::checkVeinInitialLoad()
     SourceDeviceFacade sourceFacade(ioDevice, DefaultTestSourceProperties());
     sourceFacade.setVeinInterface(&vein.veinInterface);
 
-    QTest::qWait(shortQtEventTimeout);
+    QCoreApplication::processEvents();
     QJsonObject jsonLoadParams = vein.veinDeviceParameter.getValue().toJsonObject();
     PersistentJsonState persistentState((DefaultTestSourceProperties()));
     JsonParamApi paramApi = persistentState.loadJsonState();
@@ -175,7 +175,7 @@ void test_sourcedevicefacade::checkVeinSwitchTwoStateChanges()
     sourceFacade.setStatusPollTime(0);
     sourceFacade.setVeinInterface(&vein.veinInterface);
 
-    QTest::qWait(shortQtEventTimeout); // initial vein processing
+    QCoreApplication::processEvents(); // initial vein processing
     JsonParamApi paramApi;
     paramApi.setParams(vein.veinDeviceParameter.getValue().toJsonObject());
     paramApi.setOn(true);
@@ -207,7 +207,7 @@ void test_sourcedevicefacade::checkVeinSwitchChangesLoad()
     SourceDeviceFacade sourceFacade(ioDevice, DefaultTestSourceProperties());
     sourceFacade.setVeinInterface(&vein.veinInterface);
 
-    QTest::qWait(shortQtEventTimeout); // initial vein processing
+    QCoreApplication::processEvents(); // initial vein processing
     JsonParamApi paramApi;
     paramApi.setParams(vein.veinDeviceParameter.getValue().toJsonObject());
     paramApi.setOn(true);
@@ -253,7 +253,7 @@ void test_sourcedevicefacade::checkVeinSwitchError()
     sourceFacade.setVeinInterface(&vein.veinInterface);
     sourceFacade.setStatusPollTime(10000); // never
 
-    QTest::qWait(shortQtEventTimeout); // initial processing
+    QCoreApplication::processEvents(); // initial processing
     JsonParamApi paramApi;
     paramApi.setParams(vein.veinDeviceParameter.getValue().toJsonObject());
     paramApi.setOn(true);

--- a/zera-modules/sourcemodule/tests/qtest/test_sourcedevicefacade.cpp
+++ b/zera-modules/sourcemodule/tests/qtest/test_sourcedevicefacade.cpp
@@ -79,7 +79,7 @@ void test_sourcedevicefacade::checkVeinInitialStatus()
 
     VeinComponentSetNotifier veinEventSystem(defaultEntityId);
     TVeinObjects vein(jsonStructure, &veinEventSystem);
-    veinEventSystem.addComponentToNotify(componentNameActState, &vein.veinActDeviceState.getValue());
+    veinEventSystem.addComponentToNotify(componentNameActState, &vein.veinActDeviceState);
     QList<QJsonObject> statesReceived;
     connect(&veinEventSystem, &VeinComponentSetNotifier::sigComponentChanged, [&] (QString componentName, QVariant newValue) {
         QCOMPARE(componentName, componentNameActState);
@@ -108,7 +108,7 @@ void test_sourcedevicefacade::checkVeinInitialInfo()
 
     VeinComponentSetNotifier veinEventSystem(defaultEntityId);
     TVeinObjects vein(jsonStructure, &veinEventSystem);
-    veinEventSystem.addComponentToNotify(componentNameActInfo, &vein.veinActDeviceInfo.getValue());
+    veinEventSystem.addComponentToNotify(componentNameActInfo, &vein.veinActDeviceInfo);
     QList<QJsonObject> infosReceived;
     connect(&veinEventSystem, &VeinComponentSetNotifier::sigComponentChanged, [&] (QString componentName, QVariant newValue) {
         QCOMPARE(componentName, componentNameActInfo);
@@ -134,7 +134,7 @@ void test_sourcedevicefacade::checkVeinInitialLoad()
 
     VeinComponentSetNotifier veinEventSystem(defaultEntityId);
     TVeinObjects vein(jsonStructure, &veinEventSystem);
-    veinEventSystem.addComponentToNotify(componentNameParLoad, &vein.veinDeviceParameter.getValue());
+    veinEventSystem.addComponentToNotify(componentNameParLoad, &vein.veinDeviceParameter);
     QList<QJsonObject> loadsReceived;
     connect(&veinEventSystem, &VeinComponentSetNotifier::sigComponentChanged, [&] (QString componentName, QVariant newValue) {
         QCOMPARE(componentName, componentNameParLoad);
@@ -163,7 +163,7 @@ void test_sourcedevicefacade::checkVeinSwitchTwoStateChanges()
 
     VeinComponentSetNotifier veinEventSystem(defaultEntityId);
     TVeinObjects vein(jsonStructure, &veinEventSystem);
-    veinEventSystem.addComponentToNotify(componentNameActState, &vein.veinActDeviceState.getValue());
+    veinEventSystem.addComponentToNotify(componentNameActState, &vein.veinActDeviceState);
     QList<QJsonObject> statesReceived;
     connect(&veinEventSystem, &VeinComponentSetNotifier::sigComponentChanged, [&] (QString componentName, QVariant newValue) {
         QCOMPARE(componentName, componentNameActState);
@@ -196,7 +196,7 @@ void test_sourcedevicefacade::checkVeinSwitchChangesLoad()
 
     VeinComponentSetNotifier veinEventSystem(defaultEntityId);
     TVeinObjects vein(jsonStructure, &veinEventSystem);
-    veinEventSystem.addComponentToNotify(componentNameParLoad, &vein.veinDeviceParameter.getValue());
+    veinEventSystem.addComponentToNotify(componentNameParLoad, &vein.veinDeviceParameter);
     QList<QJsonObject> loadsReceived;
     connect(&veinEventSystem, &VeinComponentSetNotifier::sigComponentChanged, [&] (QString componentName, QVariant newValue) {
         QCOMPARE(componentName, componentNameParLoad);
@@ -235,8 +235,8 @@ void test_sourcedevicefacade::checkVeinSwitchError()
 
     VeinComponentSetNotifier veinEventSystem(defaultEntityId);
     TVeinObjects vein(jsonStructure, &veinEventSystem);
-    veinEventSystem.addComponentToNotify(componentNameParLoad, &vein.veinDeviceParameter.getValue());
-    veinEventSystem.addComponentToNotify(componentNameActState, &vein.veinActDeviceState.getValue());
+    veinEventSystem.addComponentToNotify(componentNameParLoad, &vein.veinDeviceParameter);
+    veinEventSystem.addComponentToNotify(componentNameActState, &vein.veinActDeviceState);
     QList<QJsonObject> loadsReceived;
     QList<QJsonObject> statesReceived;
     connect(&veinEventSystem, &VeinComponentSetNotifier::sigComponentChanged, [&] (QString componentName, QVariant newValue) {
@@ -289,8 +289,8 @@ void test_sourcedevicefacade::checkVeinStateError()
 
     VeinComponentSetNotifier veinEventSystem(defaultEntityId);
     TVeinObjects vein(jsonStructure, &veinEventSystem);
-    veinEventSystem.addComponentToNotify(componentNameParLoad, &vein.veinDeviceParameter.getValue());
-    veinEventSystem.addComponentToNotify(componentNameActState, &vein.veinActDeviceState.getValue());
+    veinEventSystem.addComponentToNotify(componentNameParLoad, &vein.veinDeviceParameter);
+    veinEventSystem.addComponentToNotify(componentNameActState, &vein.veinActDeviceState);
     QList<QJsonObject> loadsReceived;
     QList<QJsonObject> statesReceived;
     connect(&veinEventSystem, &VeinComponentSetNotifier::sigComponentChanged, [&] (QString componentName, QVariant newValue) {

--- a/zera-modules/sourcemodule/tests/qtest/test_sourceperiodicpollerstate.cpp
+++ b/zera-modules/sourcemodule/tests/qtest/test_sourceperiodicpollerstate.cpp
@@ -79,7 +79,7 @@ void test_sourceperiodicpollerstate::pollStopNotification()
 void test_sourceperiodicpollerstate::pollChangeTimeNotification()
 {
     SourceStatePeriodicPoller poller(m_transactionNotifier, 500);
-    QTest::qWait(shortQtEventTimeout);
+    QCoreApplication::processEvents();
     QCOMPARE(m_listIoGroupsReceived.count(), 0);
     poller.setPollTime(10);
     QTest::qWait(20);

--- a/zera-modules/sourcemodule/tests/qtest/veincomponentsetnotifier-forunittest.cpp
+++ b/zera-modules/sourcemodule/tests/qtest/veincomponentsetnotifier-forunittest.cpp
@@ -16,9 +16,9 @@ VeinComponentSetNotifier::VeinComponentSetNotifier(int entityId)
     createEntity(entityId);
 }
 
-void VeinComponentSetNotifier::addComponentToNotify(QString componentName, const QVariant *componentValue)
+void VeinComponentSetNotifier::addComponentToNotify(QString componentName, cVeinModuleComponent *component)
 {
-    m_hashComponentValuesListening[componentName] = componentValue;
+    m_hashComponentsListening[componentName] = component;
 }
 
 void VeinComponentSetNotifier::createEntity(int entityId)
@@ -41,11 +41,11 @@ bool VeinComponentSetNotifier::processEvent(QEvent *t_event)
                 ComponentData *cData = static_cast<ComponentData *>(evData);
                 if(cData->eventCommand() == ComponentData::Command::CCMD_SET) {
                     QString componentName = cData->componentName();
-                    auto iter = m_hashComponentValuesListening.find(componentName);
-                    if(iter != m_hashComponentValuesListening.end()) {
+                    auto iter = m_hashComponentsListening.find(componentName);
+                    if(iter != m_hashComponentsListening.end()) {
                         int entityId = evData->entityId();
                         QVariant oldValue = m_storageHash.getStoredValue(entityId, componentName);
-                        const QVariant newValue = *iter.value();
+                        QVariant newValue = iter.value()->getValue();
                         if(oldValue != newValue) {
                             emit sigComponentChanged(componentName, newValue);
                         }

--- a/zera-modules/sourcemodule/tests/qtest/veincomponentsetnotifier-forunittest.h
+++ b/zera-modules/sourcemodule/tests/qtest/veincomponentsetnotifier-forunittest.h
@@ -15,7 +15,7 @@ class VeinComponentSetNotifier : public VeinEvent::EventSystem
     Q_OBJECT
 public:
     VeinComponentSetNotifier(int entityId);
-    void addComponentToNotify(QString componentName, const QVariant* componentValue);
+    void addComponentToNotify(QString componentName, cVeinModuleComponent* component);
 signals:
     void sigComponentChanged(QString componentName, QVariant newValue);
 private:
@@ -24,7 +24,7 @@ private:
 
     VeinEvent::EventHandler m_eventHandler;
     VeinStorage::VeinHash m_storageHash;
-    QHash <QString, const QVariant*> m_hashComponentValuesListening;
+    QHash <QString, cVeinModuleComponent*> m_hashComponentsListening;
 };
 
 #endif // VENCOMPONENTNOTIFIER_H


### PR DESCRIPTION
…Events

* Make tests a bit faster
* These are the places found that do not make the tests fail

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>