### PR TITLE
samplemodule config com5003 / mt310s2: Set PLL automatic on by default

### DIFF
--- a/zera-modules/samplemodule/src/com5003-samplemodule.xml
+++ b/zera-modules/samplemodule/src/com5003-samplemodule.xml
@@ -37,7 +37,7 @@
     </configuration>
     <parameter>
         <sample>
-            <pllauto>0</pllauto>
+            <pllauto>1</pllauto>
             <pllchannel>UL1</pllchannel>
             <range>F70Hz</range>
         </sample>

--- a/zera-modules/samplemodule/src/mt310s2-samplemodule.xml
+++ b/zera-modules/samplemodule/src/mt310s2-samplemodule.xml
@@ -39,7 +39,7 @@
     </configuration>
     <parameter>
         <sample>
-            <pllauto>0</pllauto>
+            <pllauto>1</pllauto>
             <pllchannel>UL1</pllchannel>
             <range>F70Hz</range>
         </sample>


### PR DESCRIPTION
Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>