### PR TITLE
Remove unused cPCBInterface::adjustInit

### DIFF
--- a/zera-modules-common/service-interfaces/lib/pcbinterface.cpp
+++ b/zera-modules-common/service-interfaces/lib/pcbinterface.cpp
@@ -219,13 +219,6 @@ quint32 cPCBInterface::adjustStorageClamp()
 }
 
 
-quint32 cPCBInterface::adjustInit(QString chnName, QString rngName)
-{
-    Q_D(cPCBInterface);
-    return d->adjustInit(chnName, rngName);
-}
-
-
 quint32 cPCBInterface::setAdjustGainStatus(QString chnName, QString rngName, int stat)
 {
     Q_D(cPCBInterface);

--- a/zera-modules-common/service-interfaces/lib/pcbinterface.h
+++ b/zera-modules-common/service-interfaces/lib/pcbinterface.h
@@ -48,7 +48,6 @@ public:
     virtual quint32 adjustComputation(); // all correction coefficients will be computed
     virtual quint32 adjustStorage(); // all correction data will be stored
     virtual quint32 adjustStorageClamp(); // all clamp correction data will be stored
-    virtual quint32 adjustInit(QString chnName, QString rngName);
     virtual quint32 setAdjustGainStatus(QString chnName, QString rngName, int stat);
     virtual quint32 setAdjustPhaseStatus(QString chnName, QString rngName, int stat);
     virtual quint32 setAdjustOffsetStatus(QString chnName, QString rngName, int stat);

--- a/zera-modules-common/service-interfaces/lib/pcbinterface_p.cpp
+++ b/zera-modules-common/service-interfaces/lib/pcbinterface_p.cpp
@@ -330,17 +330,6 @@ quint32 cPCBInterfacePrivate::adjustStorageClamp()
 }
 
 
-quint32 cPCBInterfacePrivate::adjustInit(QString chnName, QString rngName)
-{
-    QString cmd;
-    quint32 msgnr;
-
-    msgnr = sendCommand(cmd = QString("SENS:%1:%2:corr:init;").arg(chnName, rngName));
-    m_MsgNrCmdList[msgnr] = PCB::adjustinit;
-    return msgnr;
-}
-
-
 quint32 cPCBInterfacePrivate::setAdjustGainStatus(QString chnName, QString rngName, int stat)
 {
     QString cmd, par;

--- a/zera-modules-common/service-interfaces/lib/pcbinterface_p.h
+++ b/zera-modules-common/service-interfaces/lib/pcbinterface_p.h
@@ -121,7 +121,6 @@ public:
     virtual quint32 adjustComputation(); // all correction coefficients will be computed
     virtual quint32 adjustStorage(); // all correction data will be stored
     virtual quint32 adjustStorageClamp(); // all clamp correction data will be stored
-    virtual quint32 adjustInit(QString chnName, QString rngName);
     virtual quint32 setAdjustGainStatus(QString chnName, QString rngName, int stat);
     virtual quint32 setAdjustPhaseStatus(QString chnName, QString rngName, int stat);
     virtual quint32 setAdjustOffsetStatus(QString chnName, QString rngName, int stat);

--- a/zera-modules/adjustmentmodule/src/adjustmentmodulemeasprogram.h
+++ b/zera-modules/adjustmentmodule/src/adjustmentmodulemeasprogram.h
@@ -15,7 +15,6 @@
 #include <QHash>
 #include <QStateMachine>
 #include <QState>
-#include <QTimer>
 #include <QFinalState>
 
 namespace Zera {
@@ -51,7 +50,6 @@ enum adjustmentmoduleCmds
     setpcbadjustmentdata,
     getclampadjustmentdata,
     setclampadjustmentdata,
-    getauthorizationstatus,
     sendtransparentcmd,
 };
 
@@ -77,7 +75,6 @@ class cAdjustmentModuleMeasProgram: public cBaseMeasWorkProgram
 public:
     cAdjustmentModuleMeasProgram(cAdjustmentModule* module, Zera::Proxy::cProxy* proxy, std::shared_ptr<cBaseModuleConfiguration> pConfiguration);
     void generateInterface() override; // here we export our interface (entities)
-    bool isAuthorized();
 
 signals:
     void computationContinue();
@@ -118,7 +115,6 @@ private:
 
     int m_AdjustEntity;
     QString m_AdjustComponent;
-    bool m_bAuthorized;
     QVariant m_receivedPar;
 
     AdjustmentModuleCommonPtr m_commonObjects;
@@ -163,9 +159,6 @@ private:
     QState m_adjustphaseGetCorrState;
     QState m_adjustphaseSetNodeState;
     QFinalState m_adjustphaseFinishState;
-
-    // timer for cyclic eeprom access enable (authorization) query
-    QTimer m_AuthTimer;
 private slots:
     void onActivationReady();
     void onDeactivationReady();

--- a/zera-modules/adjustmentmodule/src/adjustvalidator.cpp
+++ b/zera-modules/adjustmentmodule/src/adjustvalidator.cpp
@@ -47,7 +47,7 @@ bool cAdjustValidator3d::isValidParam(QVariant &newValue)
             {
                 QVariant var;
                 var = (QVariant)(sl.at(2).toDouble());
-                if ((m_adjustValidatorHash[key]->dValidator.isValidParam(var)) && (m_pMeasprogram->isAuthorized()))
+                if (m_adjustValidatorHash[key]->dValidator.isValidParam(var))
                     return true;
             }
     }
@@ -90,7 +90,7 @@ bool cAdjustValidator2::isValidParam(QVariant &newValue)
         QString key;
         key = sl.at(0);
         if (m_adjustValidatorHash.contains(key))
-            if ((m_adjustValidatorHash[key]->contains(sl.at(1)))  && (m_pMeasprogram->isAuthorized()))
+            if (m_adjustValidatorHash[key]->contains(sl.at(1)))
                 return true;
     }
 
@@ -143,7 +143,7 @@ bool cAdjustValidator3i::isValidParam(QVariant &newValue)
             if (m_adjustValidatorHash[key]->rangeList.contains(sl.at(1)))
             {
                 QVariant var = (QVariant)(sl.at(2).toInt());
-                if ((m_adjustValidatorHash[key]->iValidator.isValidParam(var)) && (m_pMeasprogram->isAuthorized()))
+                if (m_adjustValidatorHash[key]->iValidator.isValidParam(var))
                     return true;
             }
     }

--- a/zera-modules/scpimodule/src/scpi-clients/scpiclient.cpp
+++ b/zera-modules/scpimodule/src/scpi-clients/scpiclient.cpp
@@ -133,6 +133,8 @@ void cSCPIClient::addSCPIClientInfo(QString key, cSCPIClientInfo *info)
 void cSCPIClient::removeSCPIClientInfo(QString key)
 {
     scpiClientInfoHash.remove(key);
+    for(auto clientInfo : qAsConst(scpiClientInfoHash))
+        delete clientInfo;
     execCmd();
 }
 


### PR DESCRIPTION
* It causes nothing but confusion
* We were tempted to remove service code either but who knows which odd clients as PZTools might require them

Signed-off-by: Andreas Müller <schnitzeltony@gmail.com>