### PR TITLE
Remove ';' from QTEST_MAIN()

### DIFF
--- a/zera-modules-common/zera-basemodule/tests/test_inttohexstringconvert.cpp
+++ b/zera-modules-common/zera-basemodule/tests/test_inttohexstringconvert.cpp
@@ -2,7 +2,7 @@
 #include "inttohexstringconvert.h"
 #include <QTest>
 
-QTEST_MAIN(test_inttohexstringconvert);
+QTEST_MAIN(test_inttohexstringconvert)
 
 void test_inttohexstringconvert::digitCount4()
 {

--- a/zera-modules-common/zera-basemodule/tests/test_phasevalidatorstringgenerator.cpp
+++ b/zera-modules-common/zera-basemodule/tests/test_phasevalidatorstringgenerator.cpp
@@ -2,7 +2,7 @@
 #include "phasevalidatorstringgenerator.h"
 #include <QTest>
 
-QTEST_MAIN(test_phasevalidatorstringgenerator);
+QTEST_MAIN(test_phasevalidatorstringgenerator)
 
 void test_phasevalidatorstringgenerator::zeroPhases()
 {

--- a/zera-modules/adjustmentmodule/tests/test_adj_config_load.cpp
+++ b/zera-modules/adjustmentmodule/tests/test_adj_config_load.cpp
@@ -4,7 +4,7 @@
 #include <QSignalSpy>
 #include <QTest>
 
-QTEST_MAIN(test_adj_config_load);
+QTEST_MAIN(test_adj_config_load)
 
 void test_adj_config_load::fileFound()
 {

--- a/zera-modules/adjustmentmodule/tests/test_adjustmentmoduleactivator.cpp
+++ b/zera-modules/adjustmentmodule/tests/test_adjustmentmoduleactivator.cpp
@@ -6,7 +6,7 @@
 #include <QByteArray>
 #include <QTest>
 
-QTEST_MAIN(test_adjustmentmoduleactivator);
+QTEST_MAIN(test_adjustmentmoduleactivator)
 
 void test_adjustmentmoduleactivator::instantiate()
 {

--- a/zera-modules/scpimodule/tests/test_scpi_config_load.cpp
+++ b/zera-modules/scpimodule/tests/test_scpi_config_load.cpp
@@ -4,7 +4,7 @@
 #include <QSignalSpy>
 #include <QTest>
 
-QTEST_MAIN(test_scpi_config_load);
+QTEST_MAIN(test_scpi_config_load)
 
 void test_scpi_config_load::fileFound()
 {

--- a/zera-modules/sourcemodule/tests/qtest/test_iotransferdata.cpp
+++ b/zera-modules/sourcemodule/tests/qtest/test_iotransferdata.cpp
@@ -3,7 +3,7 @@
 #include "io-queue/ioqueueentry.h"
 #include "iodevicebase.h"
 
-QTEST_MAIN(test_iotransferdata);
+QTEST_MAIN(test_iotransferdata)
 
 void test_iotransferdata::init()
 {

--- a/zera-modules/sourcemodule/tests/qtest/test_sourcedevicefacade.cpp
+++ b/zera-modules/sourcemodule/tests/qtest/test_sourcedevicefacade.cpp
@@ -12,7 +12,7 @@
 
 #include <QString>
 
-QTEST_MAIN(test_sourcedevicefacade);
+QTEST_MAIN(test_sourcedevicefacade)
 
 void test_sourcedevicefacade::init()
 {

--- a/zera-modules/sourcemodule/tests/qtest/test_sourcedevicemanager.cpp
+++ b/zera-modules/sourcemodule/tests/qtest/test_sourcedevicemanager.cpp
@@ -2,7 +2,7 @@
 #include "test_globals.h"
 #include "source-device/sourcedevicemanager.h"
 
-QTEST_MAIN(test_sourcedevicemanager);
+QTEST_MAIN(test_sourcedevicemanager)
 
 FinishEntry::FinishEntry(int slotNo, QUuid uuid, QString errMsg)
 {

--- a/zera-modules/sourcemodule/tests/qtest/test_sourceio.cpp
+++ b/zera-modules/sourcemodule/tests/qtest/test_sourceio.cpp
@@ -5,7 +5,7 @@
 #include "json/jsonstructureloader.h"
 #include <zera-json-params-state.h>
 
-QTEST_MAIN(test_sourceio);
+QTEST_MAIN(test_sourceio)
 
 void test_sourceio::init()
 {

--- a/zera-modules/sourcemodule/tests/qtest/test_sourceperiodicpollerstate.cpp
+++ b/zera-modules/sourcemodule/tests/qtest/test_sourceperiodicpollerstate.cpp
@@ -2,7 +2,7 @@
 #include "test_globals.h"
 #include "source-device/sourceperiodicpollerstate.h"
 
-QTEST_MAIN(test_sourceperiodicpollerstate);
+QTEST_MAIN(test_sourceperiodicpollerstate)
 
 void test_sourceperiodicpollerstate::onIoQueueGroupFinished(IoQueueEntry::Ptr workGroup)
 {

--- a/zera-modules/sourcemodule/tests/qtest/test_sourcescanner.cpp
+++ b/zera-modules/sourcemodule/tests/qtest/test_sourcescanner.cpp
@@ -5,7 +5,7 @@
 #include "source-scanner/sourcescanneriodemo.h"
 #include "source-scanner/sourcescanneriozeraserial.h"
 
-QTEST_MAIN(test_sourcescanner);
+QTEST_MAIN(test_sourcescanner)
 
 void test_sourcescanner::init()
 {

--- a/zera-modules/sourcemodule/tests/qtest/test_sourcestatecontroller.cpp
+++ b/zera-modules/sourcemodule/tests/qtest/test_sourcestatecontroller.cpp
@@ -8,7 +8,7 @@
 #include "sourcedeviceerrorinjection-forunittest.h"
 #include <zera-json-params-state.h>
 
-QTEST_MAIN(test_sourcestatecontroller);
+QTEST_MAIN(test_sourcestatecontroller)
 
 void test_sourcestatecontroller::onIoQueueGroupFinished(IoQueueEntry::Ptr workGroup)
 {

--- a/zera-modules/sourcemodule/tests/qtest/test_sourceswitchjson.cpp
+++ b/zera-modules/sourcemodule/tests/qtest/test_sourceswitchjson.cpp
@@ -4,7 +4,7 @@
 #include "source-device/sourceswitchjson.h"
 #include "sourcedeviceerrorinjection-forunittest.h"
 
-QTEST_MAIN(test_sourceswitchjson);
+QTEST_MAIN(test_sourceswitchjson)
 
 void test_sourceswitchjson::init()
 {

--- a/zera-modules/statusmodule/tests/test_status_config_load.cpp
+++ b/zera-modules/statusmodule/tests/test_status_config_load.cpp
@@ -4,7 +4,7 @@
 #include <QSignalSpy>
 #include <QTest>
 
-QTEST_MAIN(test_status_config_load);
+QTEST_MAIN(test_status_config_load)
 
 void test_status_config_load::fileFound()
 {


### PR DESCRIPTION
This ';' wasn't needed and was showing a warning on some QtCreator