### PR TITLE
zera-i2c: Introduce I2cMuxerPCA9547

### DIFF
--- a/zera-i2c/zera-i2c-devices/lib/i2cmultiplexerfactory.cpp
+++ b/zera-i2c/zera-i2c-devices/lib/i2cmultiplexerfactory.cpp
@@ -1,9 +1,15 @@
 #include "i2cmultiplexerfactory.h"
 #include <i2cmuxer.h>
+#include <i2cmuxerpca9547.h>
 
 I2cMuxerInterface::Ptr I2cMultiplexerFactory::createClampMuxer(QString deviceNode, ushort i2cMuxAdress, quint8 ctrlChannel)
 {
     return std::make_shared<I2cMuxer>(deviceNode, i2cMuxAdress, (ctrlChannel-4) | 8, 0);
+}
+
+I2cMuxerInterface::Ptr I2cMultiplexerFactory::createPCA9547Muxer(QString deviceNode, ushort i2cMuxAdress, quint8 channel0to7)
+{
+    return std::make_shared<I2cMuxerPCA9547>(deviceNode, i2cMuxAdress, channel0to7);
 }
 
 I2cMuxerInterface::Ptr I2cMultiplexerFactory::createNullMuxer()

--- a/zera-i2c/zera-i2c-devices/lib/i2cmultiplexerfactory.h
+++ b/zera-i2c/zera-i2c-devices/lib/i2cmultiplexerfactory.h
@@ -7,6 +7,7 @@ class I2cMultiplexerFactory
 {
 public:
     static I2cMuxerInterface::Ptr createClampMuxer(QString deviceNode, ushort i2cMuxAdress, quint8 ctrlChannel);
+    static I2cMuxerInterface::Ptr createPCA9547Muxer(QString deviceNode, ushort i2cMuxAdress, quint8 channel0to7);
     static I2cMuxerInterface::Ptr createNullMuxer();
 };
 

--- a/zera-i2c/zera-i2c-devices/lib/i2cmuxerpca9547.cpp
+++ b/zera-i2c/zera-i2c-devices/lib/i2cmuxerpca9547.cpp
@@ -1,0 +1,44 @@
+#include "i2cmuxerpca9547.h"
+#include <i2cutils.h>
+
+I2cMuxerPCA9547::I2cMuxerPCA9547(QString deviceNode, ushort i2cMuxAdress, int channel0to7) :
+    m_deviceNode(deviceNode),
+    m_i2cMuxAdress(i2cMuxAdress),
+    m_channel0to7(channel0to7)
+{
+    if(m_channel0to7 < 0 || m_channel0to7 > 7) {
+        qWarning("Invalid channel on PCA9547: %i - fallback to channel 0!", m_channel0to7);
+        m_channel0to7 = 0;
+    }
+}
+
+void I2cMuxerPCA9547::enableMuxChannel()
+{
+    constexpr int muxEnableVal = (1<<3);
+    switchMux(m_channel0to7 | muxEnableVal);
+}
+
+void I2cMuxerPCA9547::disableMux()
+{
+    switchMux(0);
+}
+
+QString I2cMuxerPCA9547::getDevIdString()
+{
+    return QString("%1%2").arg(m_deviceNode).arg(m_i2cMuxAdress);
+}
+
+void I2cMuxerPCA9547::switchMux(uchar muxCode)
+{
+    // 1 adr byte, 1 byte data = mux code
+    struct i2c_msg i2cMsgs;
+    i2cMsgs.addr = m_i2cMuxAdress;
+    i2cMsgs.flags = 0;
+    i2cMsgs.len = 1;
+    i2cMsgs.buf = &muxCode;
+
+    struct i2c_rdwr_ioctl_data i2cRdWrData;
+    i2cRdWrData.msgs = &i2cMsgs;
+    i2cRdWrData.nmsgs = 1;
+    I2CTransfer(m_deviceNode, m_i2cMuxAdress, &i2cRdWrData);
+}

--- a/zera-i2c/zera-i2c-devices/lib/i2cmuxerpca9547.h
+++ b/zera-i2c/zera-i2c-devices/lib/i2cmuxerpca9547.h
@@ -1,0 +1,20 @@
+#ifndef I2CMUXERPCA9547_H
+#define I2CMUXERPCA9547_H
+
+#include "i2cmuxerinterface.h"
+
+class I2cMuxerPCA9547 : public I2cMuxerInterface
+{
+public:
+    I2cMuxerPCA9547(QString deviceNode, ushort i2cMuxAdress, int channel0to7);
+    void enableMuxChannel() override;
+    void disableMux() override;
+    virtual QString getDevIdString() override;
+private:
+    void switchMux(uchar muxCode);
+    QString m_deviceNode;
+    ushort m_i2cMuxAdress;
+    int m_channel0to7;
+};
+
+#endif // I2CMUXERPCA9547_H


### PR DESCRIPTION
I2cMuxer combines knowledge of PCA9547 and Muxer as it is used inside of MT310s2.