### PR TITLE
sec1module: Remove unused/redundant meas mode list

### DIFF
--- a/zera-i2c/zera-i2c-devices/lib/mcontroller/zeramcontrollerbootloaderstopper.cpp
+++ b/zera-i2c/zera-i2c-devices/lib/mcontroller/zeramcontrollerbootloaderstopper.cpp
@@ -11,7 +11,7 @@ void ZeraMControllerBootloaderStopper::stopBootloader(int msWaitForApplicationSt
     if(!m_bootloaderStopped && !m_appStartTimer) {
         ZeraMControllerIoTemplate::atmelRM result = m_i2cCtrl->bootloaderStartProgram();
         if(result == ZeraMControllerIoTemplate::cmddone) {
-            qInfo("Stopping bootloader succeeded - wait %ims for app startup...", msWaitForApplicationStart);
+            qInfo("Stopping bootloader succeeded - wait %fs for app startup...", float(msWaitForApplicationStart/1000));
             m_appStartTimer = TimerFactoryQt::createSingleShot(msWaitForApplicationStart);
             connect(m_appStartTimer.get(), &TimerTemplateQt::sigExpired,
                     this, &ZeraMControllerBootloaderStopper::onAppStartWaitFinished);

--- a/zera-modules/modules/sec1module/configs/com5003-sec1module.xml
+++ b/zera-modules/modules/sec1module/configs/com5003-sec1module.xml
@@ -19,10 +19,6 @@
             </ethernet>
         </connectivity>
         <measure>
-            <modes>
-                <n>1</n>
-                <mod1>mrate</mod1>
-            </modes>
             <embedded>1</embedded>
             <dutinput>
                 <n>2</n>

--- a/zera-modules/modules/sec1module/configs/com5003-sec1module2.xml
+++ b/zera-modules/modules/sec1module/configs/com5003-sec1module2.xml
@@ -19,10 +19,6 @@
             </ethernet>
         </connectivity>
         <measure>
-            <modes>
-                <n>1</n>
-                <mod1>energy</mod1>
-            </modes>
             <embedded>1</embedded>
             <dutinput>
                 <n>4</n>

--- a/zera-modules/modules/sec1module/configs/com5003-sec1module3.xml
+++ b/zera-modules/modules/sec1module/configs/com5003-sec1module3.xml
@@ -19,10 +19,6 @@
             </ethernet>
         </connectivity>
         <measure>
-            <modes>
-                <n>1</n>
-                <mod1>target</mod1>
-            </modes>
             <embedded>1</embedded>
             <dutinput>
                 <n>4</n>

--- a/zera-modules/modules/sec1module/configs/mt310s2-sec1module.xml
+++ b/zera-modules/modules/sec1module/configs/mt310s2-sec1module.xml
@@ -19,10 +19,6 @@
             </ethernet>
         </connectivity>
         <measure>
-            <modes>
-                <n>1</n>
-                <mod1>mrate</mod1>
-            </modes>
             <embedded>1</embedded>
             <dutinput>
                 <n>2</n>

--- a/zera-modules/modules/sec1module/configs/mt310s2-sec1module_f1f0.xml
+++ b/zera-modules/modules/sec1module/configs/mt310s2-sec1module_f1f0.xml
@@ -19,10 +19,6 @@
             </ethernet>
         </connectivity>
         <measure>
-            <modes>
-                <n>1</n>
-                <mod1>mrate</mod1>
-            </modes>
             <embedded>1</embedded>
             <dutinput>
                 <n>2</n>

--- a/zera-modules/modules/sec1module/configs/sec1module.xsd
+++ b/zera-modules/modules/sec1module/configs/sec1module.xsd
@@ -132,16 +132,6 @@
     </xs:simpleType>
 
 
-    <xs:complexType name="modestype">
-        <xs:sequence>
-            <xs:element name="n" type="ntype" minOccurs="1" maxOccurs="1"/>
-            <xs:element name="mod1" type="modetype" minOccurs="1" maxOccurs="1"/>
-            <xs:element name="mod2" type="modetype" minOccurs="0" maxOccurs="1"/>
-            <xs:element name="mod3" type="modetype" minOccurs="0" maxOccurs="1"/>
-        </xs:sequence>
-    </xs:complexType>
-
-
     <xs:complexType name="dutinputtype">
         <xs:sequence>
             <xs:element name="n" type="ntype" minOccurs="1" maxOccurs="1"/>
@@ -230,7 +220,6 @@
 
     <xs:complexType name="configurationmeasuretype">
         <xs:sequence>
-            <xs:element name="modes" type="modestype" minOccurs="1" maxOccurs="1"/>
             <xs:element name="embedded" type="yesnotype" minOccurs="1" maxOccurs="1"/>
             <xs:element name="dutinput" type="dutinputtype" minOccurs="1" maxOccurs="1"/>
             <xs:element name="refinput" type="refinputtype" minOccurs="1" maxOccurs="1"/>

--- a/zera-modules/modules/sec1module/lib/sec1moduleconfigdata.h
+++ b/zera-modules/modules/sec1module/lib/sec1moduleconfigdata.h
@@ -57,7 +57,6 @@ public:
     };
     QList<TRefInput> m_refInpList;
     QList<QString> m_dutInpList;
-    QList<QString> m_ModeList;
     bool m_bEmbedded;
     stringParameter m_sMode;
     doubleParameter m_fDutConstant;

--- a/zera-modules/modules/sec1module/lib/sec1moduleconfiguration.cpp
+++ b/zera-modules/modules/sec1module/lib/sec1moduleconfiguration.cpp
@@ -45,7 +45,6 @@ void cSec1ModuleConfiguration::setConfiguration(QByteArray xmlString)
 
     m_ConfigXMLMap["sec1modconfpar:configuration:measure:dutinput:n"] = setDutInputCount;
     m_ConfigXMLMap["sec1modconfpar:configuration:measure:refinput:n"] = setRefInputCount;
-    m_ConfigXMLMap["sec1modconfpar:configuration:measure:modes:n"] = setModeCount;
     m_ConfigXMLMap["sec1modconfpar:configuration:measure:embedded"] = setEmbedded;
 
     m_ConfigXMLMap["sec1modconfpar:parameter:measure:dutinput"] = setDutInputPar;
@@ -181,16 +180,6 @@ void cSec1ModuleConfiguration::configXMLInfo(QString key)
             }
             break;
         }
-        case setModeCount:
-        {
-            QString name;
-            m_pSec1ModulConfigData->m_nModeCount = m_pXMLReader->getValue(key).toInt(&ok);
-            for (int i = 0; i < m_pSec1ModulConfigData->m_nModeCount; i++) {
-                m_ConfigXMLMap[QString("sec1modconfpar:configuration:measure:modes:mod%1").arg(i+1)] = setMode1Name+i;
-                m_pSec1ModulConfigData->m_ModeList.append(name);
-            }
-            break;
-        }
         case setEmbedded:
             m_pSec1ModulConfigData->m_bEmbedded = (m_pXMLReader->getValue(key).toInt(&ok) == 1);
             break;
@@ -258,11 +247,6 @@ void cSec1ModuleConfiguration::configXMLInfo(QString key)
                 cSec1ModuleConfigData::TRefInput refInput;
                 refInput.inputName = m_pXMLReader->getValue(key);
                 m_pSec1ModulConfigData->m_refInpList.replace(cmd, refInput);
-            }
-            else if ((cmd >= setMode1Name) && (cmd < setMode1Name + 32)) {
-                cmd -= setMode1Name;
-                name = m_pXMLReader->getValue(key);
-                m_pSec1ModulConfigData->m_ModeList.replace(cmd, name);
             }
             else if ((cmd >= setRefInput1Append) && (cmd < setRefInput1Append + 32)) {
                 cmd -= setRefInput1Append;

--- a/zera-modules/modules/sec1module/lib/sec1moduleconfiguration.h
+++ b/zera-modules/modules/sec1module/lib/sec1moduleconfiguration.h
@@ -22,7 +22,6 @@ enum moduleconfigstate
     setSECServerPort,
     setDutInputCount,
     setRefInputCount,
-    setModeCount,
     setEmbedded,
 
     setDutInputPar,
@@ -41,8 +40,7 @@ enum moduleconfigstate
 
     setDutInput1Name = 32,
     setRefInput1Name = 64,
-    setMode1Name = 96,
-    setRefInput1Append = 128
+    setRefInput1Append = 96
 };
 
 


### PR DESCRIPTION
It is not used and we have a single sec1modconfpar:parameter:measure:mode