### PR TITLE
scpiinterface: Follow changes in zera-scpi/cSCPI/exportSCPIModelXML

### DIFF
--- a/zera-modules/modules/scpimodule/lib/interfaceinterface.cpp
+++ b/zera-modules/modules/scpimodule/lib/interfaceinterface.cpp
@@ -53,7 +53,7 @@ void cInterfaceInterface::executeCmd(cSCPIClient *client, int cmdCode, const QSt
         if (cmd.isQuery())
         {
             QString xml;
-            m_pSCPIInterface->getSCPICmdInterface()->exportSCPIModelXML(xml);
+            m_pSCPIInterface->exportSCPIModelXML(xml);
             emit signalAnswer(xml);
             //client->receiveAnswer(xml);
         }

--- a/zera-modules/modules/scpimodule/lib/scpiinterface.cpp
+++ b/zera-modules/modules/scpimodule/lib/scpiinterface.cpp
@@ -15,7 +15,7 @@ namespace SCPIMODULE
 cSCPIInterface::cSCPIInterface(QString name)
     :m_sName(name)
 {
-    m_pSCPICmdInterface = new cSCPI(m_sName);
+    m_pSCPICmdInterface = new cSCPI();
 }
 
 
@@ -24,12 +24,10 @@ cSCPIInterface::~cSCPIInterface()
     delete m_pSCPICmdInterface;
 }
 
-
-cSCPI* cSCPIInterface::getSCPICmdInterface()
+void cSCPIInterface::exportSCPIModelXML(QString &xml)
 {
-    return m_pSCPICmdInterface;
+    m_pSCPICmdInterface->exportSCPIModelXML(xml, QMap<QString, QString>{{"DEVICE", m_sName}});
 }
-
 
 void cSCPIInterface::addSCPICommand(ScpiBaseDelegate *delegate)
 {

--- a/zera-modules/modules/scpimodule/lib/scpiinterface.h
+++ b/zera-modules/modules/scpimodule/lib/scpiinterface.h
@@ -23,7 +23,7 @@ public:
     cSCPIInterface(QString name);
     virtual ~cSCPIInterface();
 
-    cSCPI* getSCPICmdInterface();
+    void exportSCPIModelXML(QString &xml);
     void addSCPICommand(ScpiBaseDelegate* delegate);
     bool executeCmd(cSCPIClient* client, QString cmd);
 

--- a/zera-modules/modules/scpimodule/lib/scpiserver.cpp
+++ b/zera-modules/modules/scpimodule/lib/scpiserver.cpp
@@ -215,9 +215,8 @@ void cSCPIServer::setupTCPServer()
 
 void cSCPIServer::activationDone()
 {
-    cSCPI* scpiTree = m_pSCPIInterface->getSCPICmdInterface();
     QString xml;
-    scpiTree->exportSCPIModelXML(xml);
+    m_pSCPIInterface->exportSCPIModelXML(xml);
     m_veinDevIface->setValue(xml);
     m_bActive = true;
     emit activated();


### PR DESCRIPTION
* exportSCPIModelXML needs to be fed in with DEVICE tag and it's value
* cSCPI no longer needs scpi-interface name (it was used only for DEVICE tag)