### PR TITLE
rangeobsermatic: Remove unit info from range selection scpi cmd info

### DIFF
--- a/zera-modules/modules/rangemodule/lib/rangeobsermatic.cpp
+++ b/zera-modules/modules/rangemodule/lib/rangeobsermatic.cpp
@@ -653,7 +653,6 @@ void cRangeObsermatic::readGainCorrDone()
         m_ChannelRangeValidatorHash[m_ChannelNameList.at(i)] = sValidator; // systemchannelname, stringvalidator
         // we also set the channels name alias and its unit
         m_RangeParameterList.at(i)->setChannelName(s1 = m_ChannelAliasList.at(i));
-        m_RangeParameterList.at(i)->setUnit(s2 = m_RangeMeasChannelList.at(i)->getUnit());
 
         scpiInfo = new cSCPIInfo("SENSE", QString("%1:RANGE").arg(m_ChannelAliasList.at(i)), "10", m_RangeParameterList.at(i)->getName(), "0", s2);
         m_RangeParameterList.at(i)->setSCPIInfo(scpiInfo);

--- a/zera-modules/modules/sec1module/lib/sec1modulemeasprogram.cpp
+++ b/zera-modules/modules/sec1module/lib/sec1modulemeasprogram.cpp
@@ -407,7 +407,7 @@ void cSec1ModuleMeasProgram::generateInterface()
 
     m_pRefFreqInput = new VfModuleParameter(m_pModule->m_nEntityId, m_pModule->m_pModuleValidator,
                                             key = QString("ACT_RefFreqInput"),
-                                            QString("Reference frequency input to find our power module"),
+                                            QString("Reference frequency input to find power module"),
                                             QVariant(getConfData()->m_sRefInput.m_sPar));
     m_pModule->veinModuleParameterHash[key] = m_pRefFreqInput; // and for the modules interface
     m_pRefFreqInput->setSCPIInfo(new cSCPIInfo("CALCULATE",  QString("%1:REFFREQINPUT").arg(modNr), "2", m_pRefFreqInput->getName(), "0", ""));

--- a/zera-modules/modules/sec1module/lib/sec1modulemeasprogram.cpp
+++ b/zera-modules/modules/sec1module/lib/sec1modulemeasprogram.cpp
@@ -420,6 +420,7 @@ void cSec1ModuleMeasProgram::generateInterface()
     m_pModule->veinModuleParameterHash[key] = m_pUpperLimitPar; // for modules use
     dValidator = new cDoubleValidator(-100.0, 100.0, 1e-6);
     m_pUpperLimitPar->setValidator(dValidator);
+    m_pUpperLimitPar->setUnit("%");
 
     m_pLowerLimitPar = new VfModuleParameter(m_pModule->m_nEntityId, m_pModule->m_pModuleValidator,
                                                 key = QString("PAR_Lolimit"),
@@ -429,6 +430,7 @@ void cSec1ModuleMeasProgram::generateInterface()
     m_pModule->veinModuleParameterHash[key] = m_pLowerLimitPar; // for modules use
     dValidator = new cDoubleValidator(-100.0, 100.0, 1e-6);
     m_pLowerLimitPar->setValidator(dValidator);
+    m_pLowerLimitPar->setUnit("%");
 
     m_pResultUnit = new VfModuleParameter(m_pModule->m_nEntityId, m_pModule->m_pModuleValidator,
                                               key = QString("PAR_ResultUnit"),

--- a/zera-modules/modules/sem1module/src/sem1modulemeasprogram.cpp
+++ b/zera-modules/modules/sem1module/src/sem1modulemeasprogram.cpp
@@ -321,7 +321,7 @@ void cSem1ModuleMeasProgram::generateInterface()
 
     m_pRefFreqInput = new VfModuleParameter(m_pModule->m_nEntityId, m_pModule->m_pModuleValidator,
                                             key = QString("ACT_RefFreqInput"),
-                                            QString("Reference frequency input to find our power module"),
+                                            QString("Reference frequency input to find power module"),
                                             QVariant(getConfData()->m_sRefInput.m_sPar));
     m_pModule->veinModuleParameterHash[key] = m_pRefFreqInput; // and for the modules interface
     m_pRefFreqInput->setSCPIInfo(new cSCPIInfo("CALCULATE",  QString("%1:REFFREQINPUT").arg(modNr), "2", m_pRefFreqInput->getName(), "0", ""));

--- a/zera-modules/modules/sem1module/src/sem1modulemeasprogram.cpp
+++ b/zera-modules/modules/sem1module/src/sem1modulemeasprogram.cpp
@@ -246,6 +246,7 @@ void cSem1ModuleMeasProgram::generateInterface()
     m_pModule->veinModuleParameterHash[key] = m_pMeasTimePar; // for modules use
     iValidator = new cIntValidator(1, Zera::cSECInterface::maxSecCounterInitVal / 1000, 1); // counter in ms
     m_pMeasTimePar->setValidator(iValidator);
+    m_pMeasTimePar->setUnit("s");
 
     m_pT0InputPar = new VfModuleParameter(m_pModule->m_nEntityId, m_pModule->m_pModuleValidator,
                                              key = QString("PAR_T0Input"),
@@ -294,6 +295,7 @@ void cSem1ModuleMeasProgram::generateInterface()
                                           QVariant((double) 0.0));
     m_pModule->veinModuleParameterHash[key] = m_pTimeAct; // and for the modules interface
     m_pTimeAct->setSCPIInfo(new cSCPIInfo("CALCULATE", QString("%1:TIME").arg(modNr), "2", m_pTimeAct->getName(), "0", "s"));
+    m_pTimeAct->setUnit("s");
 
     m_pEnergyAct = new VfModuleParameter(m_pModule->m_nEntityId, m_pModule->m_pModuleValidator,
                                             key = QString("ACT_Energy"),
@@ -315,6 +317,7 @@ void cSem1ModuleMeasProgram::generateInterface()
                                             QVariant((double) 0.0));
     m_pModule->veinModuleParameterHash[key] = m_pResultAct; // and for the modules interface
     m_pResultAct->setSCPIInfo(new cSCPIInfo("CALCULATE",  QString("%1:RESULT").arg(modNr), "2", m_pResultAct->getName(), "0", "%"));
+    m_pResultAct->setUnit("%");
 
     m_pRefFreqInput = new VfModuleParameter(m_pModule->m_nEntityId, m_pModule->m_pModuleValidator,
                                             key = QString("ACT_RefFreqInput"),
@@ -331,6 +334,7 @@ void cSem1ModuleMeasProgram::generateInterface()
     m_pModule->veinModuleParameterHash[key] = m_pUpperLimitPar; // for modules use
     dValidator = new cDoubleValidator(-100.0, 100.0, 1e-6);
     m_pUpperLimitPar->setValidator(dValidator);
+    m_pUpperLimitPar->setUnit("%");
 
     m_pLowerLimitPar = new VfModuleParameter(m_pModule->m_nEntityId, m_pModule->m_pModuleValidator,
                                                 key = QString("PAR_Lolimit"),
@@ -340,6 +344,7 @@ void cSem1ModuleMeasProgram::generateInterface()
     m_pModule->veinModuleParameterHash[key] = m_pLowerLimitPar; // for modules use
     dValidator = new cDoubleValidator(-100.0, 100.0, 1e-6);
     m_pLowerLimitPar->setValidator(dValidator);
+    m_pLowerLimitPar->setUnit("%");
 
     m_pRatingAct = new VfModuleParameter(m_pModule->m_nEntityId, m_pModule->m_pModuleValidator,
                                                key = QString("ACT_Rating"),

--- a/zera-modules/modules/spm1module/src/spm1modulemeasprogram.cpp
+++ b/zera-modules/modules/spm1module/src/spm1modulemeasprogram.cpp
@@ -316,7 +316,7 @@ void cSpm1ModuleMeasProgram::generateInterface()
 
     m_pRefFreqInput = new VfModuleParameter(m_pModule->m_nEntityId, m_pModule->m_pModuleValidator,
                                             key = QString("ACT_RefFreqInput"),
-                                            QString("Reference frequency input to find our power module"),
+                                            QString("Reference frequency input to find power module"),
                                             QVariant(getConfData()->m_sRefInput.m_sPar));
     m_pModule->veinModuleParameterHash[key] = m_pRefFreqInput; // and for the modules interface
     m_pRefFreqInput->setSCPIInfo(new cSCPIInfo("CALCULATE",  QString("%1:REFFREQINPUT").arg(modNr), "2", m_pRefFreqInput->getName(), "0", ""));

--- a/zera-modules/modules/spm1module/src/spm1modulemeasprogram.cpp
+++ b/zera-modules/modules/spm1module/src/spm1modulemeasprogram.cpp
@@ -241,6 +241,7 @@ void cSpm1ModuleMeasProgram::generateInterface()
     m_pModule->veinModuleParameterHash[key] = m_pMeasTimePar; // for modules use
     iValidator = new cIntValidator(1, Zera::cSECInterface::maxSecCounterInitVal / 1000, 1); // counter in ms
     m_pMeasTimePar->setValidator(iValidator);
+    m_pMeasTimePar->setUnit("s");
 
     m_pT0InputPar = new VfModuleParameter(m_pModule->m_nEntityId, m_pModule->m_pModuleValidator,
                                              key = QString("PAR_T0Input"),
@@ -289,6 +290,7 @@ void cSpm1ModuleMeasProgram::generateInterface()
                                           QVariant((double) 0.0));
     m_pModule->veinModuleParameterHash[key] = m_pTimeAct; // and for the modules interface
     m_pTimeAct->setSCPIInfo(new cSCPIInfo("CALCULATE", QString("%1:TIME").arg(modNr), "2", m_pTimeAct->getName(), "0", "s"));
+    m_pTimeAct->setUnit("s");
 
     m_pEnergyAct = new VfModuleParameter(m_pModule->m_nEntityId, m_pModule->m_pModuleValidator,
                                             key = QString("ACT_Energy"),
@@ -310,6 +312,7 @@ void cSpm1ModuleMeasProgram::generateInterface()
                                             QVariant((double) 0.0));
     m_pModule->veinModuleParameterHash[key] = m_pResultAct; // and for the modules interface
     m_pResultAct->setSCPIInfo(new cSCPIInfo("CALCULATE",  QString("%1:RESULT").arg(modNr), "2", m_pResultAct->getName(), "0", "%"));
+    m_pResultAct->setUnit("%");
 
     m_pRefFreqInput = new VfModuleParameter(m_pModule->m_nEntityId, m_pModule->m_pModuleValidator,
                                             key = QString("ACT_RefFreqInput"),
@@ -326,6 +329,7 @@ void cSpm1ModuleMeasProgram::generateInterface()
     m_pModule->veinModuleParameterHash[key] = m_pUpperLimitPar; // for modules use
     dValidator = new cDoubleValidator(-100.0, 100.0, 1e-6);
     m_pUpperLimitPar->setValidator(dValidator);
+    m_pUpperLimitPar->setUnit("%");
 
     m_pLowerLimitPar = new VfModuleParameter(m_pModule->m_nEntityId, m_pModule->m_pModuleValidator,
                                                 key = QString("PAR_Lolimit"),
@@ -335,6 +339,7 @@ void cSpm1ModuleMeasProgram::generateInterface()
     m_pModule->veinModuleParameterHash[key] = m_pLowerLimitPar; // for modules use
     dValidator = new cDoubleValidator(-100.0, 100.0, 1e-6);
     m_pLowerLimitPar->setValidator(dValidator);
+    m_pLowerLimitPar->setUnit("%");
 
     m_pRatingAct = new VfModuleParameter(m_pModule->m_nEntityId, m_pModule->m_pModuleValidator,
                                                key = QString("ACT_Rating"),


### PR DESCRIPTION
Because unit is already included in 'Valid Strings' of the command.