### PR TITLE
Revert "adds config for QREF on mt310s2"

### DIFF
--- a/modules/modules/power1module/configs/lem_dc/mt310s2-power1module_U1I4.xml
+++ b/modules/modules/power1module/configs/lem_dc/mt310s2-power1module_U1I4.xml
@@ -19,9 +19,8 @@
         </connectivity>
         <measure>
             <modes>
-                <n>2</n>
+                <n>1</n>
                 <m1>2LW</m1>
-                <m2>QREF</m2>
             </modes>
             <system>
                 <pms1>m0,m7</pms1>

--- a/modules/modules/power1module/configs/lem_dc/mt310s2-power1module_U2I4.xml
+++ b/modules/modules/power1module/configs/lem_dc/mt310s2-power1module_U2I4.xml
@@ -19,9 +19,8 @@
         </connectivity>
         <measure>
             <modes>
-                <n>2</n>
+                <n>1</n>
                 <m1>2LW</m1>
-                <m2>QREF</m2>
             </modes>
             <system>
                 <pms1>m1,m7</pms1>

--- a/modules/modules/power1module/configs/lem_dc/mt310s2-power1module_U3I4.xml
+++ b/modules/modules/power1module/configs/lem_dc/mt310s2-power1module_U3I4.xml
@@ -19,9 +19,8 @@
         </connectivity>
         <measure>
             <modes>
-                <n>2</n>
+                <n>1</n>
                 <m1>2LW</m1>
-                <m2>QREF</m2>
             </modes>
             <system>
                 <pms1>m2,m7</pms1>

--- a/modules/modules/power1module/configs/lem_dc/mt310s2-power1module_U4I4.xml
+++ b/modules/modules/power1module/configs/lem_dc/mt310s2-power1module_U4I4.xml
@@ -19,9 +19,8 @@
         </connectivity>
         <measure>
             <modes>
-                <n>2</n>
+                <n>1</n>
                 <m1>2LW</m1>
-                <m2>QREF</m2>
             </modes>
             <system>
                 <pms1>m6,m7</pms1>


### PR DESCRIPTION
* QREF is not required
* Now that we display measurement mode in range-settings, it might happen that users select QREF which is not intended

This reverts commit 538773f33425874fc92a8a98ea4a2d45723e5792.