### PR TITLE
cIntValidator: Make QVariants cannot be casted from outside

### DIFF
--- a/modules-common/module-validators/intvalidator.cpp
+++ b/modules-common/module-validators/intvalidator.cpp
@@ -18,7 +18,10 @@ bool cIntValidator::isValidParam(QVariant &newValue)
 {
     bool ok;
     qint32 value = newValue.toInt(&ok);
-    return (ok && (value <= m_nMax) && (value >= m_nMin));
+    ok = ok && (value <= m_nMax) && (value >= m_nMin);
+    if(ok)
+        newValue = QVariant::fromValue<qint32>(value);
+    return ok;
 }
 
 void cIntValidator::exportMetaData(QJsonObject& jsObj)


### PR DESCRIPTION
Following scenario: SCPI starts error calculator and the Start/Stop buttons in GUI do not change.