### PR TITLE
test_taskunregisternotifier: Fix test after fixing empty parameters

### DIFF
--- a/modules-common/module-tasks/tests/pcb-server/test_taskunregisternotifier.cpp
+++ b/modules-common/module-tasks/tests/pcb-server/test_taskunregisternotifier.cpp
@@ -18,8 +18,7 @@ void test_taskunregisternotifier::checkScpiSend()
     QStringList scpiSent = pcb.getProxyClient()->getReceivedCommands();
     QCOMPARE(scpiSent.count(), 1);
     QString scpiExpectedPath = QString("SERVER:UNREGISTER");
-    // TODO (checked) server side does not expect params!!!
-    ScpiFullCmdCheckerForTest scpiChecker(scpiExpectedPath, SCPI::isCmdwP, 1);
+    ScpiFullCmdCheckerForTest scpiChecker(scpiExpectedPath, SCPI::isCmd, 0);
     QVERIFY(scpiChecker.matches(scpiSent[0]));
 }
 


### PR DESCRIPTION
Check zera-scpi a0250516ed864654a106ea939de2ffbd8d5d9fc8