### PR TITLE
Revert "test_taskunregisternotifier: Fix test after fixing empty para…

### DIFF
--- a/modules-common/module-tasks/tests/pcb-server/test_taskunregisternotifier.cpp
+++ b/modules-common/module-tasks/tests/pcb-server/test_taskunregisternotifier.cpp
@@ -18,7 +18,8 @@ void test_taskunregisternotifier::checkScpiSend()
     QStringList scpiSent = pcb.getProxyClient()->getReceivedCommands();
     QCOMPARE(scpiSent.count(), 1);
     QString scpiExpectedPath = QString("SERVER:UNREGISTER");
-    ScpiFullCmdCheckerForTest scpiChecker(scpiExpectedPath, SCPI::isCmd, 0);
+    // TODO (checked) server side does not expect params!!!
+    ScpiFullCmdCheckerForTest scpiChecker(scpiExpectedPath, SCPI::isCmdwP, 1);
     QVERIFY(scpiChecker.matches(scpiSent[0]));
 }
 


### PR DESCRIPTION
…meters"

This reverts commit a5d0764841a3acbfc79e24da713c87013a01d8f7.