### PR TITLE
lambdacalcdelegate: Set default m_activePowerMeasMode to "4LW"

### DIFF
--- a/modules/modules/lambdamodule/lib/lambdacalcdelegate.h
+++ b/modules/modules/lambdamodule/lib/lambdacalcdelegate.h
@@ -31,7 +31,7 @@ private:
     PhaseSumValues m_lambdaValues;
     PhaseSumValues m_activePowerValues;
     PhaseSumValues m_apparentPowerValues;
-    QString m_activePowerMeasMode = "";
+    QString m_activePowerMeasMode = "4LW";
     QString m_activePowerPhaseMask = "111";
     QList<VfModuleActvalue*> m_actValues;
 };


### PR DESCRIPTION
The lambda configs which do not have 'activepmeasmode' available will use default value of m_activePowerMeasMode.