### PR TITLE
Revert "scpi-doc/CMakeLists:Set 'CMAKE_INSTALL_RPATH_USE_LINK_PATH' t…

### DIFF
--- a/modulemanager/scpi-doc/CMakeLists.txt
+++ b/modulemanager/scpi-doc/CMakeLists.txt
@@ -1,8 +1,6 @@
 add_definitions(-DSCPI_DOC_BUILD_PATH="${CMAKE_INSTALL_PREFIX}/..")
 add_definitions(-DSCPI_DOC_SOURCE_PATH="${CMAKE_CURRENT_SOURCE_DIR}")
 
-set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
-
 add_executable(scpi-doc-generator
     ${CMAKE_CURRENT_SOURCE_DIR}/main.cpp
     )


### PR DESCRIPTION
…o true"

This reverts commit ba4d77603175a16693f1c3460ba15818b61fa219. It's an ugly solution from oe-build perspective.