### PR TITLE
All modules: Make sure configuration is loaded at module construction

### DIFF
--- a/modulemanager/lib/modulemanager.cpp
+++ b/modulemanager/lib/modulemanager.cpp
@@ -139,13 +139,13 @@ void ModuleManager::startModule(const QString & uniqueModuleName, const QString 
             qDebug() << "Creating module:" << uniqueModuleName << "with id:" << moduleEntityId << "with config file:" << t_xmlConfigPath;
             MeasurementModuleFactoryParam moduleParam(moduleEntityId,
                                                       moduleNum,
+                                                      t_xmlConfigData,
                                                       m_actualValueFactory,
                                                       m_setupFacade->getStorageSystem(),
                                                       m_demo);
             VirtualModule *tmpModule = tmpFactory->createModule(moduleParam);
             if(tmpModule) {
                 connect(tmpModule, &VirtualModule::addEventSystem, this, &ModuleManager::onModuleEventSystemAdded);
-                tmpModule->setConfiguration(t_xmlConfigData);
                 connect(tmpModule, &VirtualModule::moduleDeactivated, this, &ModuleManager::onStartModuleDelete);
                 connect(tmpModule, &VirtualModule::moduleActivated, this, [this](){
                     m_moduleStartLock=false;

--- a/modules-common/module-qt-plugin-interface/lib/abstractmodulefactory.h
+++ b/modules-common/module-qt-plugin-interface/lib/abstractmodulefactory.h
@@ -15,12 +15,14 @@ struct MeasurementModuleFactoryParam
 {
     MeasurementModuleFactoryParam(int entityId,
                                   int moduleNum,
+                                  QByteArray configXmlData,
                                   AbstractFactoryActValManInTheMiddlePtr actualValueFactory,
                                   VeinEvent::StorageSystem* storagesystem,
                                   bool demo);
     MeasurementModuleFactoryParam getAdjustedParam(ModuleGroupNumerator* groupNumerator);
     const int m_entityId;
     const int m_moduleNum;
+    const QByteArray m_configXmlData;
     AbstractFactoryActValManInTheMiddlePtr m_actualValueFactory;
     VeinEvent::StorageSystem* m_storagesystem;
     const bool m_demo;
@@ -28,11 +30,13 @@ struct MeasurementModuleFactoryParam
 
 inline MeasurementModuleFactoryParam::MeasurementModuleFactoryParam(int entityId,
                                                                     int moduleNum,
+                                                                    QByteArray configXmlData,
                                                                     AbstractFactoryActValManInTheMiddlePtr actualValueFactory,
                                                                     VeinEvent::StorageSystem *storagesystem,
                                                                     bool demo) :
     m_entityId(entityId),
     m_moduleNum(moduleNum),
+    m_configXmlData(configXmlData),
     m_actualValueFactory(actualValueFactory),
     m_storagesystem(storagesystem),
     m_demo(demo)
@@ -43,6 +47,7 @@ inline MeasurementModuleFactoryParam MeasurementModuleFactoryParam::getAdjustedP
 {
     return MeasurementModuleFactoryParam(m_entityId,
                                          groupNumerator->requestModuleNum(m_moduleNum),
+                                         m_configXmlData,
                                          m_actualValueFactory,
                                          m_storagesystem,
                                          m_demo);

--- a/modules-common/module-qt-plugin-interface/lib/virtualmodule.h
+++ b/modules-common/module-qt-plugin-interface/lib/virtualmodule.h
@@ -24,7 +24,6 @@ public:
     QString getVeinModuleName() { return m_sModuleName; };
     QString getSCPIModuleName() { return m_sSCPIModuleName; };
 
-    virtual void setConfiguration(QByteArray xmlConfigData) = 0; // here we set configuration and parameters
     virtual QByteArray getConfiguration() const = 0;
     virtual bool isConfigured() const = 0;
 

--- a/modules-common/zera-basemodule/lib/basemodule.h
+++ b/modules-common/zera-basemodule/lib/basemodule.h
@@ -28,10 +28,9 @@ Q_OBJECT
 public:
     cBaseModule(MeasurementModuleFactoryParam moduleParam, std::shared_ptr<cBaseModuleConfiguration> modcfg);
     virtual ~cBaseModule();
-    virtual void setConfiguration(QByteArray xmlConfigData);
-    virtual bool isConfigured() const;
-    virtual void startModule();
-    virtual void stopModule();
+    virtual bool isConfigured() const override;
+    virtual void startModule() override;
+    virtual void stopModule() override;
     virtual void exportMetaData();
 
     VeinEvent::StorageSystem* getStorageSystem();
@@ -62,7 +61,6 @@ signals:
 protected:
     // additional states for IDLE
     QState* m_pStateIDLEIdle;
-    QState* m_pStateIDLEConfXML;
     QState* m_pStateIDLEConfSetup;
 
     // additional states for RUN
@@ -70,7 +68,6 @@ protected:
     QState* m_pStateRUNDone;
     QState* m_pStateRUNDeactivate;
     QState* m_pStateRUNUnset;
-    QState* m_pStateRUNConfXML;
     QState* m_pStateRUNConfSetup;
 
     // additional states for STOP
@@ -78,7 +75,6 @@ protected:
     QState* m_pStateSTOPDone;
     QState* m_pStateSTOPDeactivate;
     QState* m_pStateSTOPUnset;
-    QState* m_pStateSTOPConfXML;
     QState* m_pStateSTOPConfSetup;
 
     // our states for base modules activation statemachine
@@ -105,7 +101,6 @@ protected:
     VfModuleComponent *m_pModuleInterfaceComponent; // here we export the modules interface as json file
     VfModuleComponent *m_pModuleEntityName;
 
-    virtual void doConfiguration(QByteArray xmlString) = 0; // here we have to do our configuration
     virtual void setupModule(); // after xml configuration we can setup and export our module
     void unsetModule(); // in case of reconfiguration we must unset module first
     virtual void startMeas() =  0;
@@ -135,7 +130,6 @@ private slots:
     void entryIdle();
     void entryIDLEIdle();
 
-    void entryConfXML();
     void entryConfSetup();
 
     void entryRunStart();

--- a/modules/adjustmentmodule/lib/adjustmentmodule.cpp
+++ b/modules/adjustmentmodule/lib/adjustmentmodule.cpp
@@ -48,12 +48,6 @@ QByteArray cAdjustmentModule::getConfiguration() const
 
 
 
-void cAdjustmentModule::doConfiguration(QByteArray xmlConfigData)
-{
-    m_pConfiguration->setConfiguration(xmlConfigData);
-}
-
-
 void cAdjustmentModule::setupModule()
 {
     emit addEventSystem(m_pModuleValidator);

--- a/modules/adjustmentmodule/lib/adjustmentmodule.h
+++ b/modules/adjustmentmodule/lib/adjustmentmodule.h
@@ -15,7 +15,6 @@ public:
     QByteArray getConfiguration() const override;
 protected:
     cAdjustmentModuleMeasProgram *m_pMeasProgram; // our measuring program, lets say the working horse
-    virtual void doConfiguration(QByteArray xmlConfigData); // here we have to do our configuration
     virtual void setupModule(); // after xml configuration we can setup and export our module
     virtual void startMeas(); // we make the measuring program start here
     virtual void stopMeas();

--- a/modules/blemodule/lib/blemodule.cpp
+++ b/modules/blemodule/lib/blemodule.cpp
@@ -46,11 +46,6 @@ QByteArray cBleModule::getConfiguration() const
     return m_pConfiguration->exportConfiguration();
 }
 
-void cBleModule::doConfiguration(QByteArray xmlConfigData)
-{
-    m_pConfiguration->setConfiguration(xmlConfigData);
-}
-
 void cBleModule::setupModule()
 {
     emit addEventSystem(m_pModuleValidator);

--- a/modules/blemodule/lib/blemodule.h
+++ b/modules/blemodule/lib/blemodule.h
@@ -18,7 +18,6 @@ public:
 
 protected:
     cBleModuleMeasProgram *m_pMeasProgram; // our measuring program, lets say the working horse
-    virtual void doConfiguration(QByteArray xmlConfigData); // here we have to do our configuration
     virtual void setupModule(); // after xml configuration we can setup and export our module
     virtual void startMeas(); // we make the measuring program start here
     virtual void stopMeas();

--- a/modules/burden1module/lib/burden1module.cpp
+++ b/modules/burden1module/lib/burden1module.cpp
@@ -51,12 +51,6 @@ QByteArray cBurden1Module::getConfiguration() const
 
 
 
-void cBurden1Module::doConfiguration(QByteArray xmlConfigData)
-{
-    m_pConfiguration->setConfiguration(xmlConfigData);
-}
-
-
 void cBurden1Module::setupModule()
 {
     emit addEventSystem(m_pModuleValidator);

--- a/modules/burden1module/lib/burden1module.h
+++ b/modules/burden1module/lib/burden1module.h
@@ -18,7 +18,6 @@ public:
 
 protected:
     cBurden1ModuleMeasProgram *m_pMeasProgram; // our measuring program, lets say the working horse
-    void doConfiguration(QByteArray xmlConfigData) override; // here we have to do our configuration
     void setupModule() override; // after xml configuration we can setup and export our module
     void startMeas() override; // we make the measuring program start here
     void stopMeas() override;

--- a/modules/dftmodule/lib/dftmodule.cpp
+++ b/modules/dftmodule/lib/dftmodule.cpp
@@ -51,12 +51,6 @@ QByteArray cDftModule::getConfiguration() const
 
 
 
-void cDftModule::doConfiguration(QByteArray xmlConfigData)
-{
-    m_pConfiguration->setConfiguration(xmlConfigData);
-}
-
-
 void cDftModule::setupModule()
 {
     emit addEventSystem(m_pModuleValidator);

--- a/modules/dftmodule/lib/dftmodule.h
+++ b/modules/dftmodule/lib/dftmodule.h
@@ -21,7 +21,6 @@ public:
 
 protected:
     cDftModuleMeasProgram *m_pMeasProgram; // our measuring program, lets say the working horse
-    virtual void doConfiguration(QByteArray xmlConfigData); // here we have to do our configuration
     virtual void setupModule(); // after xml configuration we can setup and export our module
     virtual void startMeas(); // we make the measuring program start here
     virtual void stopMeas();

--- a/modules/efficiency1module/lib/efficiency1module.cpp
+++ b/modules/efficiency1module/lib/efficiency1module.cpp
@@ -49,12 +49,6 @@ QByteArray cEfficiency1Module::getConfiguration() const
 }
 
 
-void cEfficiency1Module::doConfiguration(QByteArray xmlConfigData)
-{
-    m_pConfiguration->setConfiguration(xmlConfigData);
-}
-
-
 void cEfficiency1Module::setupModule()
 {
     emit addEventSystem(m_pModuleValidator);

--- a/modules/efficiency1module/lib/efficiency1module.h
+++ b/modules/efficiency1module/lib/efficiency1module.h
@@ -18,7 +18,6 @@ public:
 
 protected:
     cEfficiency1ModuleMeasProgram *m_pMeasProgram; // our measuring program, lets say the working horse
-    virtual void doConfiguration(QByteArray xmlConfigData); // here we have to do our configuration
     virtual void setupModule(); // after xml configuration we can setup and export our module
     virtual void startMeas(); // we make the measuring program start here
     virtual void stopMeas();

--- a/modules/fftmodule/lib/fftmodule.cpp
+++ b/modules/fftmodule/lib/fftmodule.cpp
@@ -58,12 +58,6 @@ QByteArray cFftModule::getConfiguration() const
 
 
 
-void cFftModule::doConfiguration(QByteArray xmlConfigData)
-{
-    m_pConfiguration->setConfiguration(xmlConfigData);
-}
-
-
 void cFftModule::setupModule()
 {
     emit addEventSystem(m_pModuleValidator);

--- a/modules/fftmodule/lib/fftmodule.h
+++ b/modules/fftmodule/lib/fftmodule.h
@@ -21,7 +21,6 @@ public:
 
 protected:
     cFftModuleMeasProgram *m_pMeasProgram; // our measuring program, lets say the working horse
-    virtual void doConfiguration(QByteArray xmlConfigData); // here we have to do our configuration
     virtual void setupModule(); // after xml configuration we can setup and export our module
     virtual void startMeas(); // we make the measuring program start here
     virtual void stopMeas();

--- a/modules/lambdamodule/lib/lambdamodule.cpp
+++ b/modules/lambdamodule/lib/lambdamodule.cpp
@@ -50,12 +50,6 @@ QByteArray cLambdaModule::getConfiguration() const
 
 
 
-void cLambdaModule::doConfiguration(QByteArray xmlConfigData)
-{
-    m_pConfiguration->setConfiguration(xmlConfigData);
-}
-
-
 void cLambdaModule::setupModule()
 {
     emit addEventSystem(m_pModuleValidator);

--- a/modules/lambdamodule/lib/lambdamodule.h
+++ b/modules/lambdamodule/lib/lambdamodule.h
@@ -17,7 +17,6 @@ public:
     QByteArray getConfiguration() const override;
 protected:
     cLambdaModuleMeasProgram *m_pMeasProgram; // our measuring program, lets say the working horse
-    virtual void doConfiguration(QByteArray xmlConfigData) override; // here we have to do our configuration
     virtual void setupModule() override; // after xml configuration we can setup and export our module
     virtual void startMeas() override; // we make the measuring program start here
     virtual void stopMeas() override;

--- a/modules/modemodule/lib/modemodule.cpp
+++ b/modules/modemodule/lib/modemodule.cpp
@@ -53,12 +53,6 @@ QByteArray cModeModule::getConfiguration() const
 }
 
 
-void cModeModule::doConfiguration(QByteArray xmlConfigData)
-{
-    m_pConfiguration->setConfiguration(xmlConfigData);
-}
-
-
 void cModeModule::setupModule()
 {
     emit addEventSystem(m_pModuleValidator);

--- a/modules/modemodule/lib/modemodule.h
+++ b/modules/modemodule/lib/modemodule.h
@@ -21,7 +21,6 @@ public:
 
 protected:
     cModeModuleInit *m_pModeModuleInit;
-    virtual void doConfiguration(QByteArray xmlConfigData); // here we have to do our configuration
     virtual void setupModule(); // after xml configuration we can setup and export our module
     virtual void startMeas(); // we make the measuring program start here
     virtual void stopMeas();

--- a/modules/oscimodule/lib/oscimodule.cpp
+++ b/modules/oscimodule/lib/oscimodule.cpp
@@ -51,12 +51,6 @@ QByteArray cOsciModule::getConfiguration() const
 
 
 
-void cOsciModule::doConfiguration(QByteArray xmlConfigData)
-{
-    m_pConfiguration->setConfiguration(xmlConfigData);
-}
-
-
 void cOsciModule::setupModule()
 {
     emit addEventSystem(m_pModuleValidator);

--- a/modules/oscimodule/lib/oscimodule.h
+++ b/modules/oscimodule/lib/oscimodule.h
@@ -21,7 +21,6 @@ public:
 
 protected:
     cOsciModuleMeasProgram *m_pMeasProgram; // our measuring program, lets say the working horse
-    virtual void doConfiguration(QByteArray xmlConfigData); // here we have to do our configuration
     virtual void setupModule(); // after xml configuration we can setup and export our module
     virtual void startMeas(); // we make the measuring program start here
     virtual void stopMeas();

--- a/modules/power1module/lib/power1module.cpp
+++ b/modules/power1module/lib/power1module.cpp
@@ -54,11 +54,6 @@ VfEventSystemInputComponents *cPower1Module::getPEventSystem() const
     return m_inputComponentEventSystem;
 }
 
-void cPower1Module::doConfiguration(QByteArray xmlConfigData)
-{
-    m_pConfiguration->setConfiguration(xmlConfigData);
-}
-
 void cPower1Module::setupModule()
 {
     emit addEventSystem(m_pModuleValidator);

--- a/modules/power1module/lib/power1module.h
+++ b/modules/power1module/lib/power1module.h
@@ -28,7 +28,6 @@ protected:
     // we do not inherit cBaseMeasWorkProgram so have an own event system for input components :(
     // came in 6828db17069aa94f62a976ebd3e15061976d0006 - the start of pre-scale mess
     VfEventSystemInputComponents *m_inputComponentEventSystem;
-    virtual void doConfiguration(QByteArray xmlConfigData); // here we have to do our configuration
     virtual void setupModule(); // after xml configuration we can setup and export our module
     virtual void startMeas(); // we make the measuring program start here
     virtual void stopMeas();

--- a/modules/power2module/lib/power2module.cpp
+++ b/modules/power2module/lib/power2module.cpp
@@ -51,12 +51,6 @@ QByteArray cPower2Module::getConfiguration() const
 
 
 
-void cPower2Module::doConfiguration(QByteArray xmlConfigData)
-{
-    m_pConfiguration->setConfiguration(xmlConfigData);
-}
-
-
 void cPower2Module::setupModule()
 {
     emit addEventSystem(m_pModuleValidator);

--- a/modules/power2module/lib/power2module.h
+++ b/modules/power2module/lib/power2module.h
@@ -22,7 +22,6 @@ public:
 
 protected:
     cPower2ModuleMeasProgram *m_pMeasProgram; // our measuring program, lets say the working horse
-    virtual void doConfiguration(QByteArray xmlConfigData); // here we have to do our configuration
     virtual void setupModule(); // after xml configuration we can setup and export our module
     virtual void startMeas(); // we make the measuring program start here
     virtual void stopMeas();

--- a/modules/power3module/lib/power3module.cpp
+++ b/modules/power3module/lib/power3module.cpp
@@ -51,12 +51,6 @@ QByteArray cPower3Module::getConfiguration() const
 
 
 
-void cPower3Module::doConfiguration(QByteArray xmlConfigData)
-{
-    m_pConfiguration->setConfiguration(xmlConfigData);
-}
-
-
 void cPower3Module::setupModule()
 {
     emit addEventSystem(m_pModuleValidator);

--- a/modules/power3module/lib/power3module.h
+++ b/modules/power3module/lib/power3module.h
@@ -19,7 +19,6 @@ public:
     QByteArray getConfiguration() const override;
 protected:
     cPower3ModuleMeasProgram *m_pMeasProgram; // our measuring program, lets say the working horse
-    virtual void doConfiguration(QByteArray xmlConfigData); // here we have to do our configuration
     virtual void setupModule(); // after xml configuration we can setup and export our module
     virtual void startMeas(); // we make the measuring program start here
     virtual void stopMeas();

--- a/modules/rangemodule/lib/rangemodule.cpp
+++ b/modules/rangemodule/lib/rangemodule.cpp
@@ -43,12 +43,6 @@ cRangeMeasChannel *cRangeModule::getMeasChannel(QString name)
 }
 
 
-void cRangeModule::doConfiguration(QByteArray xmlConfigData)
-{
-    m_pConfiguration->setConfiguration(xmlConfigData);
-}
-
-
 void cRangeModule::setupModule()
 {
     emit addEventSystem(m_pModuleValidator);

--- a/modules/rangemodule/lib/rangemodule.h
+++ b/modules/rangemodule/lib/rangemodule.h
@@ -28,7 +28,6 @@ protected:
     cAdjustManagement * m_pAdjustment = nullptr; // our justifying and normation program
     cRangeObsermatic *m_pRangeObsermatic = nullptr; // our range handling
     QList<cRangeMeasChannel*> m_rangeMeasChannelList; // our meas channels
-    virtual void doConfiguration(QByteArray xmlConfigData); // here we have to do our configuration
     virtual void setupModule(); // after xml configuration we can setup and export our module
     virtual void startMeas(); // we make the measuring program start here
     virtual void stopMeas();

--- a/modules/referencemodule/lib/referencemodule.cpp
+++ b/modules/referencemodule/lib/referencemodule.cpp
@@ -71,12 +71,6 @@ cReferenceMeasChannel *cReferenceModule::getMeasChannel(QString name)
 }
 
 
-void cReferenceModule::doConfiguration(QByteArray xmlConfigData)
-{
-    m_pConfiguration->setConfiguration(xmlConfigData);
-}
-
-
 void cReferenceModule::setupModule()
 {
     emit addEventSystem(m_pModuleValidator);

--- a/modules/referencemodule/lib/referencemodule.h
+++ b/modules/referencemodule/lib/referencemodule.h
@@ -23,7 +23,6 @@ protected:
     cReferenceModuleMeasProgram *m_pMeasProgram; // our measuring program, lets say the working horse
     cReferenceAdjustment *m_pReferenceAdjustment; // our justifying and normation program
     QList<cReferenceMeasChannel*> m_ReferenceMeasChannelList; // our meas channels
-    virtual void doConfiguration(QByteArray xmlConfigData); // here we have to do our configuration
     virtual void setupModule(); // after xml configuration we can setup and export our module
     virtual void startMeas(); // we make the measuring program start here
     virtual void stopMeas();

--- a/modules/rmsmodule/lib/rmsmodule.cpp
+++ b/modules/rmsmodule/lib/rmsmodule.cpp
@@ -49,12 +49,6 @@ QByteArray cRmsModule::getConfiguration() const
 
 
 
-void cRmsModule::doConfiguration(QByteArray xmlConfigData)
-{
-    m_pConfiguration->setConfiguration(xmlConfigData);
-}
-
-
 void cRmsModule::setupModule()
 {
     emit addEventSystem(m_pModuleValidator);

--- a/modules/rmsmodule/lib/rmsmodule.h
+++ b/modules/rmsmodule/lib/rmsmodule.h
@@ -19,7 +19,6 @@ public:
 
 protected:
     cRmsModuleMeasProgram *m_pMeasProgram; // our measuring program, lets say the working horse
-    virtual void doConfiguration(QByteArray xmlConfigData) override; // here we have to do our configuration
     virtual void setupModule() override; // after xml configuration we can setup and export our module
     virtual void startMeas() override; // we make the measuring program start here
     virtual void stopMeas() override;

--- a/modules/samplemodule/lib/samplemodule.cpp
+++ b/modules/samplemodule/lib/samplemodule.cpp
@@ -70,12 +70,6 @@ cPllMeasChannel* cSampleModule::getPllMeasChannel(QString name)
 }
 
 
-void cSampleModule::doConfiguration(QByteArray xmlConfigData)
-{
-    m_pConfiguration->setConfiguration(xmlConfigData);
-}
-
-
 void cSampleModule::setupModule()
 {
     emit addEventSystem(m_pModuleValidator);

--- a/modules/samplemodule/lib/samplemodule.h
+++ b/modules/samplemodule/lib/samplemodule.h
@@ -24,7 +24,6 @@ protected:
     cSampleModuleMeasProgram *m_pMeasProgram; // our measuring program, lets say the working horse
     cPllObsermatic *m_pPllObsermatic; // our pll handling
 
-    virtual void doConfiguration(QByteArray xmlConfigData); // here we have to do our configuration
     virtual void setupModule(); // after xml configuration we can setup and export our module
     virtual void startMeas(); // we make the measuring program start here
     virtual void stopMeas();

--- a/modules/scpimodule/lib/scpimodule.cpp
+++ b/modules/scpimodule/lib/scpimodule.cpp
@@ -44,12 +44,6 @@ cSCPIServer *cSCPIModule::getSCPIServer()
 }
 
 
-void cSCPIModule::doConfiguration(QByteArray xmlConfigData)
-{
-    m_pConfiguration->setConfiguration(xmlConfigData);
-}
-
-
 void cSCPIModule::setupModule()
 {
     emit addEventSystem(m_pModuleValidator);

--- a/modules/scpimodule/lib/scpimodule.h
+++ b/modules/scpimodule/lib/scpimodule.h
@@ -41,7 +41,6 @@ public:
 protected:
     cSCPIServer *m_pSCPIServer; // our server for the world
 
-    virtual void doConfiguration(QByteArray xmlConfigData) override; // here we have to do our configuration
     virtual void setupModule() override; // after xml configuration we can setup and export our module
     virtual void startMeas() override; // we make the measuring program start here
     virtual void stopMeas() override;

--- a/modules/scpimodule/testlib/modulemanagertestscpiqueue.cpp
+++ b/modules/scpimodule/testlib/modulemanagertestscpiqueue.cpp
@@ -8,17 +8,12 @@ ModuleManagerTestScpiQueue::ModuleManagerTestScpiQueue()
     addSystem(&m_storageSystem);
 }
 
-void ModuleManagerTestScpiQueue::addModule(cBaseModule *module, QString configFileFullPath)
+void ModuleManagerTestScpiQueue::addModule(cBaseModule *module)
 {
     connect(module, &ZeraModules::VirtualModule::addEventSystem, this, [&] (VeinEvent::EventSystem *eventSystem) {
         addSystem(eventSystem);
     });
 
-    QFileInfo fileInfo(configFileFullPath);
-    QFile tmpXmlConfigFile(fileInfo.absoluteFilePath());
-    qInfo("Add %s with configfile: %s...", qPrintable(module->getVeinModuleName()), qPrintable(tmpXmlConfigFile.fileName()));
-    tmpXmlConfigFile.open(QIODevice::Unbuffered | QIODevice::ReadOnly);
-    module->setConfiguration(tmpXmlConfigFile.readAll());
     TimeMachineObject::feedEventLoop();
     module->startModule();
     TimeMachineObject::feedEventLoop();

--- a/modules/scpimodule/testlib/modulemanagertestscpiqueue.h
+++ b/modules/scpimodule/testlib/modulemanagertestscpiqueue.h
@@ -12,7 +12,7 @@ class ModuleManagerTestScpiQueue : public QObject
     Q_OBJECT
 public:
     ModuleManagerTestScpiQueue();
-    void addModule(cBaseModule* module, QString configFileFullPath);
+    void addModule(cBaseModule* module);
     VeinStorage::VeinHash* getStorageSystem();
 private:
     void addSystem(VeinEvent::EventSystem* subsystem);

--- a/modules/scpimodule/tests/test_scpi_queue.cpp
+++ b/modules/scpimodule/tests/test_scpi_queue.cpp
@@ -29,8 +29,13 @@ void test_scpi_queue::initTestCase()
 void test_scpi_queue::sendStandardCmdsQueueDisabledAndEnabled()
 {
     ModuleManagerTestScpiQueue modman;
-    SCPIMODULE::ScpiModuleForTest scpiModule(MeasurementModuleFactoryParam(9999, 1, m_actValGen, modman.getStorageSystem(), true) );
-    modman.addModule(&scpiModule, QStringLiteral(CONFIG_SOURCES_SCPIMODULE) + "/" + "demo-scpimodule.xml");
+    SCPIMODULE::ScpiModuleForTest scpiModule(MeasurementModuleFactoryParam(9999,
+                                                                           1,
+                                                                           loadConfig(QStringLiteral(CONFIG_SOURCES_SCPIMODULE) + "/" + "demo-scpimodule.xml"),
+                                                                           m_actValGen,
+                                                                           modman.getStorageSystem(),
+                                                                           true) );
+    modman.addModule(&scpiModule);
 
     SCPIMODULE::ScpiTestClient client(&scpiModule, *scpiModule.getConfigData(), scpiModule.getScpiInterface());
     scpiModule.getSCPIServer()->appendClient(&client);
@@ -57,8 +62,13 @@ void test_scpi_queue::sendStandardCmdsQueueDisabledAndEnabled()
 void test_scpi_queue::sendErroneousAndCorrectStandardCmds()
 {
     ModuleManagerTestScpiQueue modman;
-    SCPIMODULE::ScpiModuleForTest scpiModule(MeasurementModuleFactoryParam(9999, 1, m_actValGen, modman.getStorageSystem(), true) );
-    modman.addModule(&scpiModule, QStringLiteral(CONFIG_SOURCES_SCPIMODULE) + "/" + "demo-scpimodule.xml");
+    SCPIMODULE::ScpiModuleForTest scpiModule(MeasurementModuleFactoryParam(9999,
+                                                                           1,
+                                                                           loadConfig(QStringLiteral(CONFIG_SOURCES_SCPIMODULE) + "/" + "demo-scpimodule.xml"),
+                                                                           m_actValGen,
+                                                                           modman.getStorageSystem(),
+                                                                           true) );
+    modman.addModule(&scpiModule);
 
     SCPIMODULE::ScpiTestClient client(&scpiModule, *scpiModule.getConfigData(), scpiModule.getScpiInterface());
     scpiModule.getSCPIServer()->appendClient(&client);
@@ -81,11 +91,21 @@ void test_scpi_queue::sendSubSystemAndStandardCommands()
     TimerFactoryQtForTest::enableTest();
 
     ModuleManagerTestScpiQueue modman;
-    RANGEMODULE::cRangeModule rangeModule( MeasurementModuleFactoryParam(1020, 1, m_actValGen, modman.getStorageSystem(), true) );
-    modman.addModule(&rangeModule, QStringLiteral(CONFIG_SOURCES_RANGEMODULE) + "/" + "mt310s2-rangemodule.xml");
+    RANGEMODULE::cRangeModule rangeModule(MeasurementModuleFactoryParam(1020,
+                                                                        1,
+                                                                        loadConfig(QStringLiteral(CONFIG_SOURCES_RANGEMODULE) + "/" + "mt310s2-rangemodule.xml"),
+                                                                        m_actValGen,
+                                                                        modman.getStorageSystem(),
+                                                                        true) );
+    modman.addModule(&rangeModule);
 
-    SCPIMODULE::ScpiModuleForTest scpiModule( MeasurementModuleFactoryParam(9999, 1, m_actValGen, modman.getStorageSystem(), true) );
-    modman.addModule(&scpiModule, QStringLiteral(CONFIG_SOURCES_SCPIMODULE) + "/" + "demo-scpimodule.xml");
+    SCPIMODULE::ScpiModuleForTest scpiModule(MeasurementModuleFactoryParam(9999,
+                                                                           1,
+                                                                           loadConfig(QStringLiteral(CONFIG_SOURCES_SCPIMODULE) + "/" + "demo-scpimodule.xml"),
+                                                                           m_actValGen,
+                                                                           modman.getStorageSystem(),
+                                                                           true) );
+    modman.addModule(&scpiModule);
 
     SCPIMODULE::ScpiTestClient client(&scpiModule, *scpiModule.getConfigData(), scpiModule.getScpiInterface());
     scpiModule.getSCPIServer()->appendClient(&client);
@@ -120,11 +140,21 @@ void test_scpi_queue::enableAndDisableQueueWhileExecutingCmds()
     TimerFactoryQtForTest::enableTest();
 
     ModuleManagerTestScpiQueue modman;
-    RANGEMODULE::cRangeModule rangeModule( MeasurementModuleFactoryParam(1020, 1, m_actValGen, modman.getStorageSystem(), true) );
-    modman.addModule(&rangeModule, QStringLiteral(CONFIG_SOURCES_RANGEMODULE) + "/" + "mt310s2-rangemodule.xml");
+    RANGEMODULE::cRangeModule rangeModule(MeasurementModuleFactoryParam(1020,
+                                                                        1,
+                                                                        loadConfig(QStringLiteral(CONFIG_SOURCES_RANGEMODULE) + "/" + "mt310s2-rangemodule.xml"),
+                                                                        m_actValGen,
+                                                                        modman.getStorageSystem(),
+                                                                        true) );
+    modman.addModule(&rangeModule);
 
-    SCPIMODULE::ScpiModuleForTest scpiModule( MeasurementModuleFactoryParam(9999, 1, m_actValGen, modman.getStorageSystem(), true) );
-    modman.addModule(&scpiModule, QStringLiteral(CONFIG_SOURCES_SCPIMODULE) + "/" + "demo-scpimodule.xml");
+    SCPIMODULE::ScpiModuleForTest scpiModule(MeasurementModuleFactoryParam(9999,
+                                                                           1,
+                                                                           loadConfig(QStringLiteral(CONFIG_SOURCES_SCPIMODULE) + "/" + "demo-scpimodule.xml"),
+                                                                           m_actValGen,
+                                                                           modman.getStorageSystem(),
+                                                                           true) );
+    modman.addModule(&scpiModule);
 
     SCPIMODULE::ScpiTestClient client(&scpiModule, *scpiModule.getConfigData(), scpiModule.getScpiInterface());
     scpiModule.getSCPIServer()->appendClient(&client);
@@ -153,11 +183,21 @@ void test_scpi_queue::disableAndEnableQueueWhileExecutingCmds()
     TimerFactoryQtForTest::enableTest();
 
     ModuleManagerTestScpiQueue modman;
-    RANGEMODULE::cRangeModule rangeModule( MeasurementModuleFactoryParam(1020, 1, m_actValGen, modman.getStorageSystem(), true) );
-    modman.addModule(&rangeModule, QStringLiteral(CONFIG_SOURCES_RANGEMODULE) + "/" + "mt310s2-rangemodule.xml");
+    RANGEMODULE::cRangeModule rangeModule(MeasurementModuleFactoryParam(1020,
+                                                                        1,
+                                                                        loadConfig(QStringLiteral(CONFIG_SOURCES_RANGEMODULE) + "/" + "mt310s2-rangemodule.xml"),
+                                                                        m_actValGen,
+                                                                        modman.getStorageSystem(),
+                                                                        true) );
+    modman.addModule(&rangeModule);
 
-    SCPIMODULE::ScpiModuleForTest scpiModule( MeasurementModuleFactoryParam(9999, 1, m_actValGen, modman.getStorageSystem(), true) );
-    modman.addModule(&scpiModule, QStringLiteral(CONFIG_SOURCES_SCPIMODULE) + "/" + "demo-scpimodule.xml");
+    SCPIMODULE::ScpiModuleForTest scpiModule(MeasurementModuleFactoryParam(9999,
+                                                                           1,
+                                                                           loadConfig(QStringLiteral(CONFIG_SOURCES_SCPIMODULE) + "/" + "demo-scpimodule.xml"),
+                                                                           m_actValGen,
+                                                                           modman.getStorageSystem(),
+                                                                           true) );
+    modman.addModule(&scpiModule);
 
     SCPIMODULE::ScpiTestClient client(&scpiModule, *scpiModule.getConfigData(), scpiModule.getScpiInterface());
     scpiModule.getSCPIServer()->appendClient(&client);
@@ -177,4 +217,12 @@ void test_scpi_queue::disableAndEnableQueueWhileExecutingCmds()
     QCOMPARE(responses.count(), 2);
     TimeMachineForTest::getInstance()->processTimers(1);
     QCOMPARE(responses.count(), 8);
+}
+
+QByteArray test_scpi_queue::loadConfig(QString configFileNameFull)
+{
+    QFile file(configFileNameFull);
+    if(file.open(QIODevice::ReadOnly))
+        return file.readAll();
+    return QByteArray();
 }

--- a/modules/scpimodule/tests/test_scpi_queue.h
+++ b/modules/scpimodule/tests/test_scpi_queue.h
@@ -16,7 +16,9 @@ private slots:
     void enableAndDisableQueueWhileExecutingCmds();
     void disableAndEnableQueueWhileExecutingCmds();
 private:
+    QByteArray loadConfig(QString configFileNameFull);
     AbstractFactoryActValManInTheMiddlePtr m_actValGen;
+
 };
 
 #endif // TEST_SCPI_QUEUE_H

--- a/modules/sec1module/lib/sec1module.cpp
+++ b/modules/sec1module/lib/sec1module.cpp
@@ -51,12 +51,6 @@ QByteArray cSec1Module::getConfiguration() const
 }
 
 
-void cSec1Module::doConfiguration(QByteArray xmlConfigData)
-{
-    m_pConfiguration->setConfiguration(xmlConfigData);
-}
-
-
 void cSec1Module::setupModule()
 {
     emit addEventSystem(m_pModuleValidator);

--- a/modules/sec1module/lib/sec1module.h
+++ b/modules/sec1module/lib/sec1module.h
@@ -20,7 +20,6 @@ public:
     cSec1Module(MeasurementModuleFactoryParam moduleParam);
     QByteArray getConfiguration() const override;
 protected:
-    virtual void doConfiguration(QByteArray xmlConfigData); // here we have to do our configuration
     virtual void setupModule(); // after xml configuration we can setup and export our module
     virtual void startMeas(); // we make the measuring program start here
     virtual void stopMeas();

--- a/modules/sem1module/lib/sem1module.cpp
+++ b/modules/sem1module/lib/sem1module.cpp
@@ -52,12 +52,6 @@ QByteArray cSem1Module::getConfiguration() const
 }
 
 
-void cSem1Module::doConfiguration(QByteArray xmlConfigData)
-{
-    m_pConfiguration->setConfiguration(xmlConfigData);
-}
-
-
 void cSem1Module::setupModule()
 {
     emit addEventSystem(m_pModuleValidator);

--- a/modules/sem1module/lib/sem1module.h
+++ b/modules/sem1module/lib/sem1module.h
@@ -19,7 +19,6 @@ public:
     cSem1Module(MeasurementModuleFactoryParam moduleParam);
     QByteArray getConfiguration() const override;
 protected:
-    virtual void doConfiguration(QByteArray xmlConfigData); // here we have to do our configuration
     virtual void setupModule(); // after xml configuration we can setup and export our module
     virtual void startMeas(); // we make the measuring program start here
     virtual void stopMeas();

--- a/modules/sourcemodule/lib/module-gluelogic/sourcemodule.cpp
+++ b/modules/sourcemodule/lib/module-gluelogic/sourcemodule.cpp
@@ -23,11 +23,6 @@ VfModuleRpc *SourceModule::getRpcEventSystem() const
     return m_rpcEventSystem;
 }
 
-void SourceModule::doConfiguration(QByteArray xmlConfigData)
-{
-    m_pConfiguration->setConfiguration(xmlConfigData);
-}
-
 void SourceModule::setupModule()
 {
     emit addEventSystem(m_pModuleValidator);

--- a/modules/sourcemodule/lib/module-gluelogic/sourcemodule.h
+++ b/modules/sourcemodule/lib/module-gluelogic/sourcemodule.h
@@ -19,7 +19,6 @@ public:
 protected:
     SourceModuleProgram *m_pProgram; // our program, lets say the working horse
 
-    virtual void doConfiguration(QByteArray xmlConfigData); // here we have to do our configuration
     virtual void setupModule(); // after xml configuration we can setup and export our module
     virtual void startMeas(); // we make the measuring program start here
     virtual void stopMeas();

--- a/modules/spm1module/lib/spm1module.cpp
+++ b/modules/spm1module/lib/spm1module.cpp
@@ -52,12 +52,6 @@ QByteArray cSpm1Module::getConfiguration() const
 }
 
 
-void cSpm1Module::doConfiguration(QByteArray xmlConfigData)
-{
-    m_pConfiguration->setConfiguration(xmlConfigData);
-}
-
-
 void cSpm1Module::setupModule()
 {
     emit addEventSystem(m_pModuleValidator);

--- a/modules/spm1module/lib/spm1module.h
+++ b/modules/spm1module/lib/spm1module.h
@@ -20,7 +20,6 @@ public:
     QByteArray getConfiguration() const override;
 protected:
     cSpm1ModuleMeasProgram *m_pMeasProgram; // our measuring program, lets say the working horse
-    virtual void doConfiguration(QByteArray xmlConfigData); // here we have to do our configuration
     virtual void setupModule(); // after xml configuration we can setup and export our module
     virtual void startMeas(); // we make the measuring program start here
     virtual void stopMeas();

--- a/modules/statusmodule/lib/statusmodule.cpp
+++ b/modules/statusmodule/lib/statusmodule.cpp
@@ -50,12 +50,6 @@ QByteArray cStatusModule::getConfiguration() const
 }
 
 
-void cStatusModule::doConfiguration(QByteArray xmlConfigData)
-{
-    m_pConfiguration->setConfiguration(xmlConfigData);
-}
-
-
 void cStatusModule::setupModule()
 {
     emit addEventSystem(m_pModuleValidator);

--- a/modules/statusmodule/lib/statusmodule.h
+++ b/modules/statusmodule/lib/statusmodule.h
@@ -20,7 +20,6 @@ public:
 
 protected:
     cStatusModuleInit *m_pStatusModuleInit;
-    virtual void doConfiguration(QByteArray xmlConfigData); // here we have to do our configuration
     virtual void setupModule(); // after xml configuration we can setup and export our module
     virtual void startMeas(); // we make the measuring program start here
     virtual void stopMeas();

--- a/modules/thdnmodule/lib/thdnmodule.cpp
+++ b/modules/thdnmodule/lib/thdnmodule.cpp
@@ -58,12 +58,6 @@ QByteArray cThdnModule::getConfiguration() const
 
 
 
-void cThdnModule::doConfiguration(QByteArray xmlConfigData)
-{
-    m_pConfiguration->setConfiguration(xmlConfigData);
-}
-
-
 void cThdnModule::setupModule()
 {
     emit addEventSystem(m_pModuleValidator);

--- a/modules/thdnmodule/lib/thdnmodule.h
+++ b/modules/thdnmodule/lib/thdnmodule.h
@@ -21,7 +21,6 @@ public:
 
 protected:
     cThdnModuleMeasProgram *m_pMeasProgram; // our measuring program, lets say the working horse
-    virtual void doConfiguration(QByteArray xmlConfigData); // here we have to do our configuration
     virtual void setupModule(); // after xml configuration we can setup and export our module
     virtual void startMeas(); // we make the measuring program start here
     virtual void stopMeas();

--- a/modules/transformer1module/lib/transformer1module.cpp
+++ b/modules/transformer1module/lib/transformer1module.cpp
@@ -53,12 +53,6 @@ QByteArray cTransformer1Module::getConfiguration() const
 
 
 
-void cTransformer1Module::doConfiguration(QByteArray xmlConfigData)
-{
-    m_pConfiguration->setConfiguration(xmlConfigData);
-}
-
-
 void cTransformer1Module::setupModule()
 {
     emit addEventSystem(m_pModuleValidator);

--- a/modules/transformer1module/lib/transformer1module.h
+++ b/modules/transformer1module/lib/transformer1module.h
@@ -24,7 +24,6 @@ public:
 protected:
     cTransformer1ModuleObservation *m_pTransformer1ModuleObservation;
     cTransformer1ModuleMeasProgram *m_pMeasProgram; // our measuring program, lets say the working horse
-    virtual void doConfiguration(QByteArray xmlConfigData); // here we have to do our configuration
     virtual void setupModule(); // after xml configuration we can setup and export our module
     virtual void startMeas(); // we make the measuring program start here
     virtual void stopMeas();


### PR DESCRIPTION
* That was a blocker/pitfall ever since: When can we rely on a valid configuration or where does code go requiring configuration
* We plan to replace man in the middle implementation by replacing service interfaces. At least for demo we need to pass in configuration details
* Was not the most trivial job to get this done in a jungle of nested states and variables. We ran tests, started and changed sessions in demo to verify things are still working as before