### PR TITLE
Some modules: Do not link demo libs against modules bit static libs

### DIFF
--- a/modules/dftmodule/demolib/CMakeLists.txt
+++ b/modules/dftmodule/demolib/CMakeLists.txt
@@ -18,7 +18,7 @@ target_include_directories(dftmodule-demolib
 
 target_link_libraries(dftmodule-demolib
     PUBLIC
-    dftmodule
+    dftmodule-static
     module-service-interfaces
     Zera::service-interfaces-demolib
     Zera::zera-timers

--- a/modules/fftmodule/demolib/CMakeLists.txt
+++ b/modules/fftmodule/demolib/CMakeLists.txt
@@ -18,7 +18,7 @@ target_include_directories(fftmodule-demolib
 
 target_link_libraries(fftmodule-demolib
     PUBLIC
-    fftmodule
+    fftmodule-static
     module-service-interfaces
     Zera::service-interfaces-demolib
     Zera::zera-timers

--- a/modules/rangemodule/demolib/CMakeLists.txt
+++ b/modules/rangemodule/demolib/CMakeLists.txt
@@ -18,7 +18,7 @@ target_include_directories(rangemodule-demolib
 
 target_link_libraries(rangemodule-demolib
     PUBLIC
-    rangemodule
+    rangemodule-static
     module-service-interfaces
     Zera::service-interfaces-demolib
     Zera::zera-timers

--- a/modules/rmsmodule/demolib/CMakeLists.txt
+++ b/modules/rmsmodule/demolib/CMakeLists.txt
@@ -18,7 +18,7 @@ target_include_directories(rmsmodule-demolib
 
 target_link_libraries(rmsmodule-demolib
     PUBLIC
-    rmsmodule
+    rmsmodule-static
     module-service-interfaces
     Zera::service-interfaces-demolib
     Zera::zera-timers


### PR DESCRIPTION
After Fedora update / build from scratch modulemanager complained for missing shared libraries