### PR TITLE
sec/sem/spm: Avoid QVariant type changes

### DIFF
--- a/modules/sec1module/lib/sec1modulemeasprogram.cpp
+++ b/modules/sec1module/lib/sec1modulemeasprogram.cpp
@@ -374,7 +374,7 @@ void cSec1ModuleMeasProgram::generateInterface()
     m_pStatusAct = new VfModuleParameter(m_pModule->getEntityId(), m_pModule->m_pModuleValidator,
                                             key = QString("ACT_Status"),
                                             QString("Status: 0:Idle 1:Waiting for first pulse 2:Started 4:Ready 8:Aborted"),
-                                            QVariant((int)0) );
+                                            QVariant((quint32)0) );
     m_pModule->m_veinModuleParameterMap[key] =  m_pStatusAct; // for modules use
     m_pStatusAct->setSCPIInfo(new cSCPIInfo("CALCULATE",  QString("%1:STATUS").arg(modNr), "2", m_pStatusAct->getName(), "0", ""));
 

--- a/modules/sem1module/lib/sem1modulemeasprogram.cpp
+++ b/modules/sem1module/lib/sem1modulemeasprogram.cpp
@@ -282,7 +282,7 @@ void cSem1ModuleMeasProgram::generateInterface()
     m_pStatusAct = new VfModuleParameter(m_pModule->getEntityId(), m_pModule->m_pModuleValidator,
                                             key = QString("ACT_Status"),
                                             QString("State: 0:Idle 1:First pulse wait 2:Started 4:Ready 8:Aborted"),
-                                            QVariant((int)0) );
+                                            QVariant((quint32)0) );
     m_pModule->m_veinModuleParameterMap[key] =  m_pStatusAct; // and for the modules interface
     m_pStatusAct->setSCPIInfo(new cSCPIInfo("CALCULATE",  QString("%1:STATUS").arg(modNr), "2", m_pStatusAct->getName(), "0", ""));
 

--- a/modules/spm1module/lib/spm1modulemeasprogram.cpp
+++ b/modules/spm1module/lib/spm1modulemeasprogram.cpp
@@ -276,7 +276,7 @@ void cSpm1ModuleMeasProgram::generateInterface()
     m_pStatusAct = new VfModuleParameter(m_pModule->getEntityId(), m_pModule->m_pModuleValidator,
                                             key = QString("ACT_Status"),
                                             QString("State: 0:Idle 1:First pulse wait 2:Started 4:Ready 8:Aborted"),
-                                            QVariant((int)0) );
+                                            QVariant((quint32)0) );
     m_pModule->m_veinModuleParameterMap[key] =  m_pStatusAct; // and for the modules interface
     m_pStatusAct->setSCPIInfo(new cSCPIInfo("CALCULATE",  QString("%1:STATUS").arg(modNr), "2", m_pStatusAct->getName(), "0", ""));
 


### PR DESCRIPTION
* Loads of warnings when moving GUI to 'Energy register' area: | QVariant type change detected on entity 1200 / component ACT_Status: Old int / new uint
* ACT_Status is read only so we can keep quint32
* Question: Why do these occur hundreds of time per second even when no measurement is running?