### PR TITLE
power1module: Make phase component descriptions more precise

### DIFF
--- a/modules/power1module/lib/power1modulemeasprogram.h
+++ b/modules/power1module/lib/power1modulemeasprogram.h
@@ -97,6 +97,8 @@ private:
     void setPhaseMaskValidator(std::shared_ptr<MeasMode> mode);
     void updatePhaseMaskVeinComponents(std::shared_ptr<MeasMode> mode);
     bool canChangePhaseMask(std::shared_ptr<MeasMode> mode);
+    QString getChannelNameEarlyHack(QString channelName);
+    QString getPhasePowerDescription(int measSystemNo);
     struct RangeMaxVals
     {
         double maxU = 0.0;

--- a/modules/power1module/tests/test-data/dumpActual.json
+++ b/modules/power1module/tests/test-data/dumpActual.json
@@ -21,17 +21,17 @@
                 },
                 "ACT_PQS1": {
                     "ChannelName": "P1",
-                    "Description": "Actual power value phase 1",
+                    "Description": "Actual power value U1/I1",
                     "Unit": "W"
                 },
                 "ACT_PQS2": {
                     "ChannelName": "P2",
-                    "Description": "Actual power value phase 2",
+                    "Description": "Actual power value U2/I2",
                     "Unit": "W"
                 },
                 "ACT_PQS3": {
                     "ChannelName": "P3",
-                    "Description": "Actual power value phase 3",
+                    "Description": "Actual power value U3/I3",
                     "Unit": "W"
                 },
                 "ACT_PQS4": {

--- a/modules/power1module/tests/test-data/dumpInitial.json
+++ b/modules/power1module/tests/test-data/dumpInitial.json
@@ -21,17 +21,17 @@
                 },
                 "ACT_PQS1": {
                     "ChannelName": "P1",
-                    "Description": "Actual power value phase 1",
+                    "Description": "Actual power value U1/I1",
                     "Unit": "W"
                 },
                 "ACT_PQS2": {
                     "ChannelName": "P2",
-                    "Description": "Actual power value phase 2",
+                    "Description": "Actual power value U2/I2",
                     "Unit": "W"
                 },
                 "ACT_PQS3": {
                     "ChannelName": "P3",
-                    "Description": "Actual power value phase 3",
+                    "Description": "Actual power value U3/I3",
                     "Unit": "W"
                 },
                 "ACT_PQS4": {


### PR DESCRIPTION
Had a discussion with HuHü: It showed that is not easy to understand where to get power values in EMOB DC sessions from.
The problem is that initially the channel / index link was fix 1/2/3/SUM. Unfortunately we have shipped and cannot change SCPI structure with current design (the-cat-is-out-problem).

So just change the SCPI doc to explain better where to find values.