### PR TITLE
rangemodulemeasprogram: Log measured frequency to understand DSP load…

### DIFF
--- a/modules/rangemodule/demolib/demodspinterfacerange.cpp
+++ b/modules/rangemodule/demolib/demodspinterfacerange.cpp
@@ -68,7 +68,7 @@ QVector<float> DemoDspInterfaceRange::demoChannelRms()
 double DemoDspInterfaceRange::demoFrequency()
 {
     double freqBase= 50.0;
-    double randPlusMinusOne = 2.0 * (double)rand() / RAND_MAX - 1.0;
+    double randPlusMinusOne = 1.0 * (double)rand() / RAND_MAX - 0.5;
     double randOffset = 0.02 * randPlusMinusOne;
     double randRMS = (1+randOffset) * freqBase;
     return randRMS;

--- a/modules/rangemodule/lib/rangemodulemeasprogram.cpp
+++ b/modules/rangemodule/lib/rangemodulemeasprogram.cpp
@@ -7,6 +7,7 @@
 #include <reply.h>
 #include <proxy.h>
 #include <timerfactoryqt.h>
+#include <math.h>
 
 namespace RANGEMODULE
 {
@@ -402,8 +403,14 @@ void cRangeModuleMeasProgram::setInterfaceActualValues(QVector<float> *actualVal
         int i;
         for (i = 0; i < m_veinActValueList.count()-1; i++) // we set n peak values first
             m_veinActValueList.at(i)->setValue(QVariant((*actualValues)[i]));
-        m_veinActValueList.at(i)->setValue(QVariant((*actualValues)[2*i]));
-
+        const int frqIndex = 2*i;
+        float freq = (*actualValues)[frqIndex];
+        m_veinActValueList.at(i)->setValue(QVariant(freq));
+        QString displayedFreq = QString("%1Hz").arg(round(freq), 0, 'f', 0);
+        if(m_lastDisplayedFreq != displayedFreq) {
+            m_lastDisplayedFreq = displayedFreq;
+            qInfo("Measured frequency: ~%s", qPrintable(displayedFreq));
+        }
         int rmsOffsetInActual = m_ChannelList.count();
         for(int rmsNo=0; rmsNo<m_ChannelList.count(); rmsNo++)
             m_veinRmsValueList.at(rmsNo)->setValue(QVariant((*actualValues)[rmsNo+rmsOffsetInActual]));

--- a/modules/rangemodule/lib/rangemodulemeasprogram.h
+++ b/modules/rangemodule/lib/rangemodulemeasprogram.h
@@ -5,10 +5,10 @@
 #include <basemeasmodule.h>
 #include <basedspmeasprogram.h>
 #include <proxyclient.h>
+#include <timertemplateqt.h>
 #include <QList>
 #include <QStateMachine>
 #include <QFinalState>
-#include <timerperiodicqt.h>
 
 namespace RANGEMODULE
 {
@@ -22,6 +22,8 @@ enum rangemoduleCmds
     cmdlist2dsp,
     activatedsp,
     deactivatedsp,
+    readdspmaxload,
+    resetdspmaxload,
     dataaquistion,
     freepgrmem,
     freeusermem
@@ -82,11 +84,17 @@ private:
 
     // statemachine for reading actual values
     QStateMachine m_dataAcquisitionMachine;
+    QState m_getDspMaxLoadState;
+    QState m_resetDspMaxLoadState;
     QState m_dataAcquisitionState;
     QFinalState m_dataAcquisitionDoneState;
 
+    int m_lastFrequencyRounded = 0;
+    int m_lastDspLoad = 0;
+    bool m_loadLogAndResetRequired = true;
+    TimerTemplateQtPtr m_loadLogTimer;
+
     Zera::ProxyClientPtr m_rmClient;
-    QString m_lastDisplayedFreq;
 
     void setActualValuesNames();
     void setSCPIMeasInfo();
@@ -110,6 +118,8 @@ private slots:
     void freeUSERMem();
     void deactivateDSPdone();
 
+    void getDspMaxLoadState();
+    void resetDspMaxLoadState();
     void dataAcquisitionDSP();
     void dataReadDSP();
 

--- a/modules/rangemodule/lib/rangemodulemeasprogram.h
+++ b/modules/rangemodule/lib/rangemodulemeasprogram.h
@@ -86,6 +86,7 @@ private:
     QFinalState m_dataAcquisitionDoneState;
 
     Zera::ProxyClientPtr m_rmClient;
+    QString m_lastDisplayedFreq;
 
     void setActualValuesNames();
     void setSCPIMeasInfo();

--- a/modules/scpimodule/lib/scpiserver.cpp
+++ b/modules/scpimodule/lib/scpiserver.cpp
@@ -154,7 +154,6 @@ void cSCPIServer::destroySerialScpi()
     if (m_bSerialScpiActive) {
         m_bSerialScpiActive = false;
         deleteSCPIClient(m_pSerialClient);
-        delete m_pSerialClient;
         m_pSerialPort->close();
         deleteSerialPort();
         m_pSerialClient = nullptr;


### PR DESCRIPTION
… changes

DSP's cycle time depends on PLL frequency. Up to now the significant change of DSP load made us think that something is wrong. To avoid investigations in the wrong directions, log measured (PLL) frequency.