### PR TITLE
scpiserver: Use 'deleteSCPIClient' to delete client when shutting dow…

### DIFF
--- a/modulemanager/tests/CMakeLists.txt
+++ b/modulemanager/tests/CMakeLists.txt
@@ -37,6 +37,7 @@ SETUP_QTESTS_MODULEMANAGER(
     test_modman_regression_all_sessions
     test_sessionnamesmappingjson
     test_modman_with_vf_logger
+    test_change_session
     )
 
 target_sources(test_modman_regression_all_sessions
@@ -49,3 +50,9 @@ target_sources(test_modman_with_vf_logger
     ${XML_SCHEMA_RESOURCE_RMSMODULE}
     test-data/test-data.qrc
 )
+
+target_sources(test_change_session
+  PRIVATE
+  ${XML_SCHEMA_RESOURCES_ALL}
+)
+

--- a/modulemanager/tests/test_change_session.cpp
+++ b/modulemanager/tests/test_change_session.cpp
@@ -1,0 +1,102 @@
+#include "test_change_session.h"
+#include "testfactoryserviceinterfaces.h"
+#include "modulemanagertestrunner.h"
+#include "modulemanagerconfig.h"
+#include "modulemanagerconfigtest.h"
+#include "scpimoduleclientblocked.h"
+#include "vf_client_component_setter.h"
+#include <timemachineobject.h>
+#include <QTest>
+
+
+QTEST_MAIN(test_change_session)
+
+static int constexpr systemEntityId = 0;
+
+void test_change_session::initTestCase()
+{
+    m_serviceInterfaceFactory = std::make_shared<TestFactoryServiceInterfaces>();
+    TestModuleManager::supportOeTests();
+    TestModuleManager::pointToInstalledSessionFiles();
+    qputenv("QT_FATAL_CRITICALS", "1");
+}
+
+void test_change_session::changeSessionMt310s2FromComponent()
+{
+    TestLicenseSystem licenseSystem;
+    ModuleManagerSetupFacade modManSetupFacade(&licenseSystem);
+
+    TestModuleManager modMan(&modManSetupFacade, m_serviceInterfaceFactory);
+    modMan.loadAllAvailableModulePlugins();
+    modMan.setupConnections();
+    modMan.startAllTestServices("mt310s2", false);
+    modMan.changeSessionFile("mt310s2-meas-session.json");
+    modMan.waitUntilModulesAreReady();
+
+    QVariant oldValue = modManSetupFacade.getStorageSystem()->getStoredValue(systemEntityId, "Session");
+    QEvent* event = VfClientComponentSetter::generateEvent(systemEntityId, "Session", oldValue, "mt310s2-dc-session.json");
+    emit modManSetupFacade.getStorageSystem()->sigSendEvent(event); // could be any event system
+    modMan.waitUntilModulesAreReady();
+    QCOMPARE(modManSetupFacade.getStorageSystem()->getStoredValue(systemEntityId, "Session").toString(), QString("mt310s2-dc-session.json"));
+    modMan.destroyModulesAndWaitUntilAllShutdown();
+}
+
+void test_change_session::changeSessionMt310s2SCPICmd()
+{
+    TestLicenseSystem licenseSystem;
+    ModuleManagerSetupFacade modManSetupFacade(&licenseSystem);
+
+    TestModuleManager modMan(&modManSetupFacade, m_serviceInterfaceFactory);
+    modMan.loadAllAvailableModulePlugins();
+    modMan.setupConnections();
+    modMan.startAllTestServices("mt310s2", false);
+    modMan.changeSessionFile("mt310s2-meas-session.json");
+    modMan.waitUntilModulesAreReady();
+
+    ScpiModuleClientBlocked client;
+    client.sendReceive("CONFIGURATION:SYST:NAMESESSION EMOB DC;");
+    modMan.waitUntilModulesAreReady();
+    QCOMPARE(modManSetupFacade.getStorageSystem()->getStoredValue(systemEntityId, "Session").toString(), QString("mt310s2-emob-session-dc.json"));
+    modMan.destroyModulesAndWaitUntilAllShutdown();
+}
+
+void test_change_session::changeSessionCom5003FromComponent()
+{
+    ModulemanagerConfig::setDemoDevice("com5003", false);
+    TestLicenseSystem licenseSystem;
+    ModuleManagerSetupFacade modManSetupFacade(&licenseSystem);
+
+    TestModuleManager modMan(&modManSetupFacade, m_serviceInterfaceFactory);
+    modMan.loadAllAvailableModulePlugins();
+    modMan.setupConnections();
+    modMan.startAllTestServices("com5003", false);
+    modMan.changeSessionFile("com5003-meas-session.json");
+    modMan.waitUntilModulesAreReady();
+
+    QVariant oldValue = modManSetupFacade.getStorageSystem()->getStoredValue(systemEntityId, "Session");
+    QEvent* event = VfClientComponentSetter::generateEvent(systemEntityId, "Session", oldValue, "com5003-ced-session.json");
+    emit modManSetupFacade.getStorageSystem()->sigSendEvent(event); // could be any event system
+    modMan.waitUntilModulesAreReady();
+    QCOMPARE(modManSetupFacade.getStorageSystem()->getStoredValue(systemEntityId, "Session").toString(), QString("com5003-ced-session.json"));
+    modMan.destroyModulesAndWaitUntilAllShutdown();
+}
+
+void test_change_session::changeSessionCom5003SCPICmd()
+{
+    ModulemanagerConfig::setDemoDevice("com5003", false);
+    TestLicenseSystem licenseSystem;
+    ModuleManagerSetupFacade modManSetupFacade(&licenseSystem);
+
+    TestModuleManager modMan(&modManSetupFacade, m_serviceInterfaceFactory);
+    modMan.loadAllAvailableModulePlugins();
+    modMan.setupConnections();
+    modMan.startAllTestServices("com5003", false);
+    modMan.changeSessionFile("com5003-meas-session.json");
+    modMan.waitUntilModulesAreReady();
+
+    ScpiModuleClientBlocked client;
+    client.sendReceive("CONFIGURATION:SYST:NAMESESSION 3 Systems / 2 Wires;");
+    modMan.waitUntilModulesAreReady();
+    QCOMPARE(modManSetupFacade.getStorageSystem()->getStoredValue(systemEntityId, "Session").toString(), QString("com5003-perphase-session.json"));
+    modMan.destroyModulesAndWaitUntilAllShutdown();
+}

--- a/modulemanager/tests/test_change_session.h
+++ b/modulemanager/tests/test_change_session.h
@@ -1,0 +1,22 @@
+#ifndef TEST_CHANGE_SESSION_H
+#define TEST_CHANGE_SESSION_H
+
+#include "testmodulemanager.h"
+#include <QObject>
+
+class test_change_session : public QObject
+{
+    Q_OBJECT
+private slots:
+    void initTestCase();
+    void changeSessionMt310s2FromComponent();
+    void changeSessionMt310s2SCPICmd();
+
+    void changeSessionCom5003FromComponent();
+    void changeSessionCom5003SCPICmd();
+
+private:
+    AbstractFactoryServiceInterfacesPtr m_serviceInterfaceFactory;
+};
+
+#endif // TEST_CHANGE_SESSION_H

--- a/modules/scpimodule/lib/scpiserver.cpp
+++ b/modules/scpimodule/lib/scpiserver.cpp
@@ -186,7 +186,7 @@ void cSCPIServer::addSCPIClient()
 void cSCPIServer::deleteSCPIClient(cSCPIClient *client)
 {
     // don't use for other than remove from list - it is destroyed and not usable
-    if(client) {
+    if(m_SCPIClientList.contains(client)) {
         m_pModule->scpiParameterCmdInfoHash.remove(client->getComponentName());
         m_SCPIClientList.removeAll(client);
         delete client;
@@ -244,7 +244,7 @@ void cSCPIServer::shutdownTCPServer()
     if (m_bSerialScpiActive)
         destroySerialScpi();
     for(auto client : qAsConst(m_SCPIClientList))
-        delete client;
+        deleteSCPIClient(client);
     m_SCPIClientList.clear();
     m_pTcpServer->close();
     emit deactivationContinue();


### PR DESCRIPTION
…n server

* deleteSCPIClient is also protected against double deletion of cSCPIClient.
* We saw double deletion when modman session was changed while a telnet client was connected. During session change, once all modules are destroyed, scpiserver is shutdown and all clients are deleted. But deleting an ethernet client causes disconnection of TCPSocket which calls the deleteSCPIClient slot. This slot is also prepared to delete client because of socket-disconnection (designed from point of view of client terminating connection).