### PR TITLE
rangemodule/adjustment.cpp: fix persistency, load up with config values

### DIFF
--- a/modules/rangemodule/lib/adjustment.cpp
+++ b/modules/rangemodule/lib/adjustment.cpp
@@ -149,6 +149,7 @@ void cAdjustManagement::generateInterface()
         m_pModule->m_veinModuleParameterMap[key] = pParameter; // for modules use
         m_invertedPhasesParList.append(pParameter);
         connect(pParameter, &VfModuleParameter::sigValueChanged, this, &cAdjustManagement::parInvertedPhaseStateChanged);
+        m_ChannelList[i]->setInvertedPhaseState(m_adjustmentConfig->m_senseChannelInvertParameter[i].m_nActive);
     }
 }
 


### PR DESCRIPTION
inverted phase state was correctly read from config, but initial state was never propagated to the correct place. Only on change