### PR TITLE
tests: Explicitly call 'TestModuleManager::enableTests' in tests whic…

### DIFF
--- a/modulemanager/testlib/testmodulemanager.cpp
+++ b/modulemanager/testlib/testmodulemanager.cpp
@@ -9,8 +9,9 @@
 #include <vtcp_workerfactorymethodstest.h>
 #include <QDir>
 
-void TestModuleManager::supportOeTests()
+void TestModuleManager::enableTests()
 {
+    TimerFactoryQtForTest::enableTest();
     JsonSessionLoaderTest::supportOeTests();
     ModulemanagerConfigTest::supportOeTests();
     VeinTcp::TcpWorkerFactoryMethodsTest::enableMockNetwork();

--- a/modulemanager/testlib/testmodulemanager.h
+++ b/modulemanager/testlib/testmodulemanager.h
@@ -6,7 +6,7 @@
 class TestModuleManager : public ZeraModules::ModuleManager
 {
 public:
-    static void supportOeTests();
+    static void enableTests();
     static void pointToInstalledSessionFiles();
 
     explicit TestModuleManager(ModuleManagerSetupFacade *setupFacade,

--- a/modulemanager/tests/test_change_session.cpp
+++ b/modulemanager/tests/test_change_session.cpp
@@ -17,7 +17,7 @@ static int constexpr systemEntityId = 0;
 void test_change_session::initTestCase()
 {
     m_serviceInterfaceFactory = std::make_shared<TestFactoryServiceInterfaces>();
-    TestModuleManager::supportOeTests();
+    TestModuleManager::enableTests();
     TestModuleManager::pointToInstalledSessionFiles();
     qputenv("QT_FATAL_CRITICALS", "1");
 }

--- a/modulemanager/tests/test_modman_regression_all_sessions.cpp
+++ b/modulemanager/tests/test_modman_regression_all_sessions.cpp
@@ -13,7 +13,7 @@ void test_modman_regression_all_sessions::initTestCase()
 {
     m_serviceInterfaceFactory = std::make_shared<TestFactoryServiceInterfaces>();
     ModuleManagerSetupFacade::registerMetaTypeStreamOperators();
-    TestModuleManager::supportOeTests();
+    TestModuleManager::enableTests();
     TestModuleManager::pointToInstalledSessionFiles();
     qputenv("QT_FATAL_CRITICALS", "1");
     qputenv("QT_LOGGING_RULES", "*.debug=false;*.info=false");

--- a/modulemanager/tests/test_plugin_load.cpp
+++ b/modulemanager/tests/test_plugin_load.cpp
@@ -9,7 +9,7 @@ QTEST_MAIN(test_plugin_load)
 void test_plugin_load::initTestCase()
 {
     ModuleManagerSetupFacade::registerMetaTypeStreamOperators();
-    TestModuleManager::supportOeTests();
+    TestModuleManager::enableTests();
     TestModuleManager::pointToInstalledSessionFiles();
     qputenv("QT_FATAL_CRITICALS", "1");
 }

--- a/modules/adjustmentmodule/tests/test_adj_module_gain.cpp
+++ b/modules/adjustmentmodule/tests/test_adj_module_gain.cpp
@@ -13,6 +13,12 @@ constexpr double testangle = 0;
 constexpr double testfrequency = 50;
 constexpr double limitOffset = 0.1;
 
+void test_adj_module_gain::initTestCase()
+{
+    TestModuleManager::enableTests();
+    TestModuleManager::pointToInstalledSessionFiles();
+}
+
 void test_adj_module_gain::noActValuesWithPermission()
 {
     ModuleManagerTestRunner testRunner(":/session-minimal.json", true);

--- a/modules/adjustmentmodule/tests/test_adj_module_gain.h
+++ b/modules/adjustmentmodule/tests/test_adj_module_gain.h
@@ -8,6 +8,8 @@ class test_adj_module_gain : public QObject
 {
     Q_OBJECT
 private slots:
+    void initTestCase();
+
     void noActValuesWithPermission();
     void validActValuesWithPermission();
     void validActValuesWithoutPermission();

--- a/modules/adjustmentmodule/tests/test_adj_module_offset.cpp
+++ b/modules/adjustmentmodule/tests/test_adj_module_offset.cpp
@@ -11,6 +11,12 @@ constexpr double testcurrent = 10;
 constexpr double testangle = 0;
 constexpr double testfrequency = 50;
 
+void test_adj_module_offset::initTestCase()
+{
+    TestModuleManager::enableTests();
+    TestModuleManager::pointToInstalledSessionFiles();
+}
+
 void test_adj_module_offset::validActValuesWithPermission()
 {
     ModuleManagerTestRunner testRunner(":/session-minimal-dc.json", true);

--- a/modules/adjustmentmodule/tests/test_adj_module_offset.h
+++ b/modules/adjustmentmodule/tests/test_adj_module_offset.h
@@ -8,6 +8,8 @@ class test_adj_module_offset : public QObject
 {
     Q_OBJECT
 private slots:
+    void initTestCase();
+
     void validActValuesWithPermission();
     void validActValuesWithoutPermission();
 

--- a/modules/adjustmentmodule/tests/test_adj_module_phase.cpp
+++ b/modules/adjustmentmodule/tests/test_adj_module_phase.cpp
@@ -15,6 +15,12 @@ constexpr double limitOffset = 0.1;
 constexpr double angleUL2 = 120;
 
 
+void test_adj_module_phase::initTestCase()
+{
+    TestModuleManager::enableTests();
+    TestModuleManager::pointToInstalledSessionFiles();
+}
+
 void test_adj_module_phase::noActValuesWithPermission()
 {
     ModuleManagerTestRunner testRunner(":/session-minimal.json", true);

--- a/modules/adjustmentmodule/tests/test_adj_module_phase.h
+++ b/modules/adjustmentmodule/tests/test_adj_module_phase.h
@@ -8,6 +8,8 @@ class test_adj_module_phase : public QObject
 {
     Q_OBJECT
 private slots:
+    void initTestCase();
+
     void noActValuesWithPermission();
     void validActValuesWithPermission();
     void validActValuesWithoutPermission();

--- a/modules/adjustmentmodule/tests/test_adj_module_regression.cpp
+++ b/modules/adjustmentmodule/tests/test_adj_module_regression.cpp
@@ -17,6 +17,12 @@ static int constexpr fftEntityId = 1060;
 static int constexpr adjEntityId = 1190;
 static int constexpr scpiEntityId = 9999;
 
+void test_adj_module_regression::initTestCase()
+{
+    TestModuleManager::enableTests();
+    TestModuleManager::pointToInstalledSessionFiles();
+}
+
 void test_adj_module_regression::minimalSession()
 {
     ModuleManagerTestRunner testRunner(":/session-minimal.json");

--- a/modules/adjustmentmodule/tests/test_adj_module_regression.h
+++ b/modules/adjustmentmodule/tests/test_adj_module_regression.h
@@ -7,6 +7,8 @@ class test_adj_module_regression : public QObject
 {
     Q_OBJECT
 private slots:
+    void initTestCase();
+
     void minimalSession();
     void veinDumpInitial();
 

--- a/modules/scpimodule/tests/test_scpi_cmds_in_session.cpp
+++ b/modules/scpimodule/tests/test_scpi_cmds_in_session.cpp
@@ -14,6 +14,12 @@
 
 QTEST_MAIN(test_scpi_cmds_in_session)
 
+void test_scpi_cmds_in_session::initTestCase()
+{
+    TestModuleManager::enableTests();
+    TestModuleManager::pointToInstalledSessionFiles();
+}
+
 void test_scpi_cmds_in_session::initialSession()
 {
     ModuleManagerTestRunner testRunner(":/session-scpi-only.json");

--- a/modules/scpimodule/tests/test_scpi_cmds_in_session.h
+++ b/modules/scpimodule/tests/test_scpi_cmds_in_session.h
@@ -7,6 +7,8 @@ class test_scpi_cmds_in_session : public QObject
 {
     Q_OBJECT
 private slots:
+    void initTestCase();
+
     void initialSession();
     void initialTestClient();
     void minScpiDevIface();

--- a/modules/scpimodule/tests/test_scpi_queue.cpp
+++ b/modules/scpimodule/tests/test_scpi_queue.cpp
@@ -23,6 +23,8 @@ void test_scpi_queue::initTestCase()
 {
     m_serviceInterfaceFactory = std::make_shared<DemoFactoryServiceInterfaces>();
     TimerFactoryQtForTest::enableTest();
+    TestModuleManager::enableTests();
+    TestModuleManager::pointToInstalledSessionFiles();
 }
 
 void test_scpi_queue::cleanup()


### PR DESCRIPTION
…h use ModuleManager

'TestModuleManager::enableTests' makes tests compatible for OE. To be effective, it must be called before ModuleManager is created. There are some tests which use ModuleManager but don't call 'TestModuleManager::enableTests', these tests rely on same helper functions called from constructor of TesModuleManager.