### PR TITLE
Remove leftovers of Zera::vf-tcp-testlib

### DIFF
--- a/modulemanager/testlib/CMakeLists.txt
+++ b/modulemanager/testlib/CMakeLists.txt
@@ -26,7 +26,6 @@ target_link_libraries(zera-modulemanager-testlib
     zera-modulemanager-lib
     module-service-interfaces-testlib
     Zera::VfConvenientCode
-    Zera::vf-tcp-testlib
     Zera::veinserver-testlib
 )
 

--- a/modulemanager/testlib/modulemanagertestrunner.cpp
+++ b/modulemanager/testlib/modulemanagertestrunner.cpp
@@ -1,12 +1,9 @@
 #include "modulemanagertestrunner.h"
 #include "vf_client_component_setter.h"
-#include "vf_entity_component_event_item.h"
 #include <timemachineobject.h>
-#include <vtcp_workerfactorymethodstest.h>
 
 ModuleManagerTestRunner::ModuleManagerTestRunner(QString sessionFileName, bool initialAdjPermission, QString deviceName)
 {
-    VeinTcp::TcpWorkerFactoryMethodsTest::enableMockNetwork();
     m_licenseSystem = std::make_unique<TestLicenseSystem>();
     m_modmanFacade = std::make_unique<ModuleManagerSetupFacade>(m_licenseSystem.get());
     m_serviceInterfaceFactory = std::make_shared<TestFactoryServiceInterfaces>();

--- a/modulemanager/testlib/testmodulemanager.cpp
+++ b/modulemanager/testlib/testmodulemanager.cpp
@@ -6,7 +6,6 @@
 #include <testfactoryi2cctrl.h>
 #include <timemachineobject.h>
 #include <timerfactoryqtfortest.h>
-#include <vtcp_workerfactorymethodstest.h>
 #include <QDir>
 
 void TestModuleManager::enableTests()
@@ -14,7 +13,6 @@ void TestModuleManager::enableTests()
     TimerFactoryQtForTest::enableTest();
     JsonSessionLoaderTest::supportOeTests();
     ModulemanagerConfigTest::supportOeTests();
-    VeinTcp::TcpWorkerFactoryMethodsTest::enableMockNetwork();
 }
 
 void TestModuleManager::pointToInstalledSessionFiles()


### PR DESCRIPTION
In case we really need mock network let's use vf-tcp-mock-networklib. By that a more fine grained real/mock network configuration can be chosen