### PR TITLE
rangeobsermatic: Modify RegExValidator for 'PAR_PreScalingGroup' so t…

### DIFF
--- a/modulemanager/tests/test-data/veinDumps/com5003-ced-session.json
+++ b/modulemanager/tests/test-data/veinDumps/com5003-ced-session.json
@@ -540,21 +540,21 @@
                 "PAR_PreScalingGroup0": {
                     "Description": "Scaling factor for group k (see configuration)",
                     "Validation": {
-                        "Data": "^[1-9][0-9]*\\/[1-9][0-9]*(\\*\\((sqrt\\(3\\)|1\\/sqrt\\(3\\))\\))?$",
+                        "Data": "^[1-9][0-9]*\\/[1-9][0-9]*(\\*\\((1|sqrt\\(3\\)|1\\/sqrt\\(3\\))\\))?$",
                         "Type": "REGEX"
                     }
                 },
                 "PAR_PreScalingGroup1": {
                     "Description": "Scaling factor for group k (see configuration)",
                     "Validation": {
-                        "Data": "^[1-9][0-9]*\\/[1-9][0-9]*(\\*\\((sqrt\\(3\\)|1\\/sqrt\\(3\\))\\))?$",
+                        "Data": "^[1-9][0-9]*\\/[1-9][0-9]*(\\*\\((1|sqrt\\(3\\)|1\\/sqrt\\(3\\))\\))?$",
                         "Type": "REGEX"
                     }
                 },
                 "PAR_PreScalingGroup2": {
                     "Description": "Scaling factor for group k (see configuration)",
                     "Validation": {
-                        "Data": "^[1-9][0-9]*\\/[1-9][0-9]*(\\*\\((sqrt\\(3\\)|1\\/sqrt\\(3\\))\\))?$",
+                        "Data": "^[1-9][0-9]*\\/[1-9][0-9]*(\\*\\((1|sqrt\\(3\\)|1\\/sqrt\\(3\\))\\))?$",
                         "Type": "REGEX"
                     }
                 },

--- a/modulemanager/tests/test-data/veinDumps/com5003-ced-session.json
+++ b/modulemanager/tests/test-data/veinDumps/com5003-ced-session.json
@@ -871,7 +871,7 @@
         "PAR_PreScalingEnabledGroup0": 0,
         "PAR_PreScalingEnabledGroup1": 0,
         "PAR_PreScalingEnabledGroup2": 0,
-        "PAR_PreScalingGroup0": "1/1",
+        "PAR_PreScalingGroup0": "1/1*(1)",
         "PAR_PreScalingGroup1": "1/1",
         "PAR_PreScalingGroup2": "1/1",
         "PAR_RangeAutomatic": 0,

--- a/modulemanager/tests/test-data/veinDumps/com5003-meas-session.json
+++ b/modulemanager/tests/test-data/veinDumps/com5003-meas-session.json
@@ -543,21 +543,21 @@
                 "PAR_PreScalingGroup0": {
                     "Description": "Scaling factor for group k (see configuration)",
                     "Validation": {
-                        "Data": "^[1-9][0-9]*\\/[1-9][0-9]*(\\*\\((sqrt\\(3\\)|1\\/sqrt\\(3\\))\\))?$",
+                        "Data": "^[1-9][0-9]*\\/[1-9][0-9]*(\\*\\((1|sqrt\\(3\\)|1\\/sqrt\\(3\\))\\))?$",
                         "Type": "REGEX"
                     }
                 },
                 "PAR_PreScalingGroup1": {
                     "Description": "Scaling factor for group k (see configuration)",
                     "Validation": {
-                        "Data": "^[1-9][0-9]*\\/[1-9][0-9]*(\\*\\((sqrt\\(3\\)|1\\/sqrt\\(3\\))\\))?$",
+                        "Data": "^[1-9][0-9]*\\/[1-9][0-9]*(\\*\\((1|sqrt\\(3\\)|1\\/sqrt\\(3\\))\\))?$",
                         "Type": "REGEX"
                     }
                 },
                 "PAR_PreScalingGroup2": {
                     "Description": "Scaling factor for group k (see configuration)",
                     "Validation": {
-                        "Data": "^[1-9][0-9]*\\/[1-9][0-9]*(\\*\\((sqrt\\(3\\)|1\\/sqrt\\(3\\))\\))?$",
+                        "Data": "^[1-9][0-9]*\\/[1-9][0-9]*(\\*\\((1|sqrt\\(3\\)|1\\/sqrt\\(3\\))\\))?$",
                         "Type": "REGEX"
                     }
                 },

--- a/modulemanager/tests/test-data/veinDumps/com5003-meas-session.json
+++ b/modulemanager/tests/test-data/veinDumps/com5003-meas-session.json
@@ -874,7 +874,7 @@
         "PAR_PreScalingEnabledGroup0": 0,
         "PAR_PreScalingEnabledGroup1": 0,
         "PAR_PreScalingEnabledGroup2": 0,
-        "PAR_PreScalingGroup0": "1/1",
+        "PAR_PreScalingGroup0": "1/1*(1)",
         "PAR_PreScalingGroup1": "1/1",
         "PAR_PreScalingGroup2": "1/1",
         "PAR_RangeAutomatic": 0,

--- a/modulemanager/tests/test-data/veinDumps/com5003-perphase-session.json
+++ b/modulemanager/tests/test-data/veinDumps/com5003-perphase-session.json
@@ -544,21 +544,21 @@
                 "PAR_PreScalingGroup0": {
                     "Description": "Scaling factor for group k (see configuration)",
                     "Validation": {
-                        "Data": "^[1-9][0-9]*\\/[1-9][0-9]*(\\*\\((sqrt\\(3\\)|1\\/sqrt\\(3\\))\\))?$",
+                        "Data": "^[1-9][0-9]*\\/[1-9][0-9]*(\\*\\((1|sqrt\\(3\\)|1\\/sqrt\\(3\\))\\))?$",
                         "Type": "REGEX"
                     }
                 },
                 "PAR_PreScalingGroup1": {
                     "Description": "Scaling factor for group k (see configuration)",
                     "Validation": {
-                        "Data": "^[1-9][0-9]*\\/[1-9][0-9]*(\\*\\((sqrt\\(3\\)|1\\/sqrt\\(3\\))\\))?$",
+                        "Data": "^[1-9][0-9]*\\/[1-9][0-9]*(\\*\\((1|sqrt\\(3\\)|1\\/sqrt\\(3\\))\\))?$",
                         "Type": "REGEX"
                     }
                 },
                 "PAR_PreScalingGroup2": {
                     "Description": "Scaling factor for group k (see configuration)",
                     "Validation": {
-                        "Data": "^[1-9][0-9]*\\/[1-9][0-9]*(\\*\\((sqrt\\(3\\)|1\\/sqrt\\(3\\))\\))?$",
+                        "Data": "^[1-9][0-9]*\\/[1-9][0-9]*(\\*\\((1|sqrt\\(3\\)|1\\/sqrt\\(3\\))\\))?$",
                         "Type": "REGEX"
                     }
                 },

--- a/modulemanager/tests/test-data/veinDumps/com5003-perphase-session.json
+++ b/modulemanager/tests/test-data/veinDumps/com5003-perphase-session.json
@@ -875,7 +875,7 @@
         "PAR_PreScalingEnabledGroup0": 0,
         "PAR_PreScalingEnabledGroup1": 0,
         "PAR_PreScalingEnabledGroup2": 0,
-        "PAR_PreScalingGroup0": "1/1",
+        "PAR_PreScalingGroup0": "1/1*(1)",
         "PAR_PreScalingGroup1": "1/1",
         "PAR_PreScalingGroup2": "1/1",
         "PAR_RangeAutomatic": 0,

--- a/modulemanager/tests/test-data/veinDumps/com5003-ref-session.json
+++ b/modulemanager/tests/test-data/veinDumps/com5003-ref-session.json
@@ -498,21 +498,21 @@
                 "PAR_PreScalingGroup0": {
                     "Description": "Scaling factor for group k (see configuration)",
                     "Validation": {
-                        "Data": "^[1-9][0-9]*\\/[1-9][0-9]*(\\*\\((sqrt\\(3\\)|1\\/sqrt\\(3\\))\\))?$",
+                        "Data": "^[1-9][0-9]*\\/[1-9][0-9]*(\\*\\((1|sqrt\\(3\\)|1\\/sqrt\\(3\\))\\))?$",
                         "Type": "REGEX"
                     }
                 },
                 "PAR_PreScalingGroup1": {
                     "Description": "Scaling factor for group k (see configuration)",
                     "Validation": {
-                        "Data": "^[1-9][0-9]*\\/[1-9][0-9]*(\\*\\((sqrt\\(3\\)|1\\/sqrt\\(3\\))\\))?$",
+                        "Data": "^[1-9][0-9]*\\/[1-9][0-9]*(\\*\\((1|sqrt\\(3\\)|1\\/sqrt\\(3\\))\\))?$",
                         "Type": "REGEX"
                     }
                 },
                 "PAR_PreScalingGroup2": {
                     "Description": "Scaling factor for group k (see configuration)",
                     "Validation": {
-                        "Data": "^[1-9][0-9]*\\/[1-9][0-9]*(\\*\\((sqrt\\(3\\)|1\\/sqrt\\(3\\))\\))?$",
+                        "Data": "^[1-9][0-9]*\\/[1-9][0-9]*(\\*\\((1|sqrt\\(3\\)|1\\/sqrt\\(3\\))\\))?$",
                         "Type": "REGEX"
                     }
                 },

--- a/modulemanager/tests/test-data/veinDumps/com5003-ref-session.json
+++ b/modulemanager/tests/test-data/veinDumps/com5003-ref-session.json
@@ -829,7 +829,7 @@
         "PAR_PreScalingEnabledGroup0": 0,
         "PAR_PreScalingEnabledGroup1": 0,
         "PAR_PreScalingEnabledGroup2": 0,
-        "PAR_PreScalingGroup0": "1/1",
+        "PAR_PreScalingGroup0": "1/1*(1)",
         "PAR_PreScalingGroup1": "1/1",
         "PAR_PreScalingGroup2": "1/1",
         "PAR_RangeAutomatic": 0,

--- a/modulemanager/tests/test-data/veinDumps/mt310s2-ced-session.json
+++ b/modulemanager/tests/test-data/veinDumps/mt310s2-ced-session.json
@@ -590,14 +590,14 @@
                 "PAR_PreScalingGroup0": {
                     "Description": "Scaling factor for group k (see configuration)",
                     "Validation": {
-                        "Data": "^[1-9][0-9]*\\/[1-9][0-9]*(\\*\\((sqrt\\(3\\)|1\\/sqrt\\(3\\))\\))?$",
+                        "Data": "^[1-9][0-9]*\\/[1-9][0-9]*(\\*\\((1|sqrt\\(3\\)|1\\/sqrt\\(3\\))\\))?$",
                         "Type": "REGEX"
                     }
                 },
                 "PAR_PreScalingGroup1": {
                     "Description": "Scaling factor for group k (see configuration)",
                     "Validation": {
-                        "Data": "^[1-9][0-9]*\\/[1-9][0-9]*(\\*\\((sqrt\\(3\\)|1\\/sqrt\\(3\\))\\))?$",
+                        "Data": "^[1-9][0-9]*\\/[1-9][0-9]*(\\*\\((1|sqrt\\(3\\)|1\\/sqrt\\(3\\))\\))?$",
                         "Type": "REGEX"
                     }
                 },

--- a/modulemanager/tests/test-data/veinDumps/mt310s2-ced-session.json
+++ b/modulemanager/tests/test-data/veinDumps/mt310s2-ced-session.json
@@ -985,7 +985,7 @@
         "PAR_Overload": 0,
         "PAR_PreScalingEnabledGroup0": 0,
         "PAR_PreScalingEnabledGroup1": 0,
-        "PAR_PreScalingGroup0": "1/1",
+        "PAR_PreScalingGroup0": "1/1*(1)",
         "PAR_PreScalingGroup1": "1/1",
         "PAR_RangeAutomatic": 0,
         "SIG_Channel1OVL": 0,

--- a/modulemanager/tests/test-data/veinDumps/mt310s2-dc-session.json
+++ b/modulemanager/tests/test-data/veinDumps/mt310s2-dc-session.json
@@ -590,14 +590,14 @@
                 "PAR_PreScalingGroup0": {
                     "Description": "Scaling factor for group k (see configuration)",
                     "Validation": {
-                        "Data": "^[1-9][0-9]*\\/[1-9][0-9]*(\\*\\((sqrt\\(3\\)|1\\/sqrt\\(3\\))\\))?$",
+                        "Data": "^[1-9][0-9]*\\/[1-9][0-9]*(\\*\\((1|sqrt\\(3\\)|1\\/sqrt\\(3\\))\\))?$",
                         "Type": "REGEX"
                     }
                 },
                 "PAR_PreScalingGroup1": {
                     "Description": "Scaling factor for group k (see configuration)",
                     "Validation": {
-                        "Data": "^[1-9][0-9]*\\/[1-9][0-9]*(\\*\\((sqrt\\(3\\)|1\\/sqrt\\(3\\))\\))?$",
+                        "Data": "^[1-9][0-9]*\\/[1-9][0-9]*(\\*\\((1|sqrt\\(3\\)|1\\/sqrt\\(3\\))\\))?$",
                         "Type": "REGEX"
                     }
                 },

--- a/modulemanager/tests/test-data/veinDumps/mt310s2-dc-session.json
+++ b/modulemanager/tests/test-data/veinDumps/mt310s2-dc-session.json
@@ -985,7 +985,7 @@
         "PAR_Overload": 0,
         "PAR_PreScalingEnabledGroup0": 0,
         "PAR_PreScalingEnabledGroup1": 0,
-        "PAR_PreScalingGroup0": "1/1",
+        "PAR_PreScalingGroup0": "1/1*(1)",
         "PAR_PreScalingGroup1": "1/1",
         "PAR_RangeAutomatic": 0,
         "SIG_Channel1OVL": 0,

--- a/modulemanager/tests/test-data/veinDumps/mt310s2-emob-session-ac.json
+++ b/modulemanager/tests/test-data/veinDumps/mt310s2-emob-session-ac.json
@@ -987,7 +987,7 @@
         "PAR_Overload": 0,
         "PAR_PreScalingEnabledGroup0": 0,
         "PAR_PreScalingEnabledGroup1": 0,
-        "PAR_PreScalingGroup0": "1/1",
+        "PAR_PreScalingGroup0": "1/1*(1)",
         "PAR_PreScalingGroup1": "1/1",
         "PAR_RangeAutomatic": 0,
         "SIG_Channel1OVL": 0,

--- a/modulemanager/tests/test-data/veinDumps/mt310s2-emob-session-ac.json
+++ b/modulemanager/tests/test-data/veinDumps/mt310s2-emob-session-ac.json
@@ -592,14 +592,14 @@
                 "PAR_PreScalingGroup0": {
                     "Description": "Scaling factor for group k (see configuration)",
                     "Validation": {
-                        "Data": "^[1-9][0-9]*\\/[1-9][0-9]*(\\*\\((sqrt\\(3\\)|1\\/sqrt\\(3\\))\\))?$",
+                        "Data": "^[1-9][0-9]*\\/[1-9][0-9]*(\\*\\((1|sqrt\\(3\\)|1\\/sqrt\\(3\\))\\))?$",
                         "Type": "REGEX"
                     }
                 },
                 "PAR_PreScalingGroup1": {
                     "Description": "Scaling factor for group k (see configuration)",
                     "Validation": {
-                        "Data": "^[1-9][0-9]*\\/[1-9][0-9]*(\\*\\((sqrt\\(3\\)|1\\/sqrt\\(3\\))\\))?$",
+                        "Data": "^[1-9][0-9]*\\/[1-9][0-9]*(\\*\\((1|sqrt\\(3\\)|1\\/sqrt\\(3\\))\\))?$",
                         "Type": "REGEX"
                     }
                 },

--- a/modulemanager/tests/test-data/veinDumps/mt310s2-emob-session-dc.json
+++ b/modulemanager/tests/test-data/veinDumps/mt310s2-emob-session-dc.json
@@ -587,14 +587,14 @@
                 "PAR_PreScalingGroup0": {
                     "Description": "Scaling factor for group k (see configuration)",
                     "Validation": {
-                        "Data": "^[1-9][0-9]*\\/[1-9][0-9]*(\\*\\((sqrt\\(3\\)|1\\/sqrt\\(3\\))\\))?$",
+                        "Data": "^[1-9][0-9]*\\/[1-9][0-9]*(\\*\\((1|sqrt\\(3\\)|1\\/sqrt\\(3\\))\\))?$",
                         "Type": "REGEX"
                     }
                 },
                 "PAR_PreScalingGroup1": {
                     "Description": "Scaling factor for group k (see configuration)",
                     "Validation": {
-                        "Data": "^[1-9][0-9]*\\/[1-9][0-9]*(\\*\\((sqrt\\(3\\)|1\\/sqrt\\(3\\))\\))?$",
+                        "Data": "^[1-9][0-9]*\\/[1-9][0-9]*(\\*\\((1|sqrt\\(3\\)|1\\/sqrt\\(3\\))\\))?$",
                         "Type": "REGEX"
                     }
                 },

--- a/modulemanager/tests/test-data/veinDumps/mt310s2-emob-session-dc.json
+++ b/modulemanager/tests/test-data/veinDumps/mt310s2-emob-session-dc.json
@@ -982,7 +982,7 @@
         "PAR_Overload": 0,
         "PAR_PreScalingEnabledGroup0": 0,
         "PAR_PreScalingEnabledGroup1": 0,
-        "PAR_PreScalingGroup0": "1/1",
+        "PAR_PreScalingGroup0": "1/1*(1)",
         "PAR_PreScalingGroup1": "1/1",
         "PAR_RangeAutomatic": 0,
         "SIG_Channel1OVL": 0,

--- a/modulemanager/tests/test-data/veinDumps/mt310s2-meas-session.json
+++ b/modulemanager/tests/test-data/veinDumps/mt310s2-meas-session.json
@@ -993,7 +993,7 @@
         "PAR_Overload": 0,
         "PAR_PreScalingEnabledGroup0": 0,
         "PAR_PreScalingEnabledGroup1": 0,
-        "PAR_PreScalingGroup0": "1/1",
+        "PAR_PreScalingGroup0": "1/1*(1)",
         "PAR_PreScalingGroup1": "1/1",
         "PAR_RangeAutomatic": 0,
         "SIG_Channel1OVL": 0,

--- a/modulemanager/tests/test-data/veinDumps/mt310s2-meas-session.json
+++ b/modulemanager/tests/test-data/veinDumps/mt310s2-meas-session.json
@@ -598,14 +598,14 @@
                 "PAR_PreScalingGroup0": {
                     "Description": "Scaling factor for group k (see configuration)",
                     "Validation": {
-                        "Data": "^[1-9][0-9]*\\/[1-9][0-9]*(\\*\\((sqrt\\(3\\)|1\\/sqrt\\(3\\))\\))?$",
+                        "Data": "^[1-9][0-9]*\\/[1-9][0-9]*(\\*\\((1|sqrt\\(3\\)|1\\/sqrt\\(3\\))\\))?$",
                         "Type": "REGEX"
                     }
                 },
                 "PAR_PreScalingGroup1": {
                     "Description": "Scaling factor for group k (see configuration)",
                     "Validation": {
-                        "Data": "^[1-9][0-9]*\\/[1-9][0-9]*(\\*\\((sqrt\\(3\\)|1\\/sqrt\\(3\\))\\))?$",
+                        "Data": "^[1-9][0-9]*\\/[1-9][0-9]*(\\*\\((1|sqrt\\(3\\)|1\\/sqrt\\(3\\))\\))?$",
                         "Type": "REGEX"
                     }
                 },

--- a/modules/rangemodule/lib/rangeobsermatic.cpp
+++ b/modules/rangemodule/lib/rangeobsermatic.cpp
@@ -152,7 +152,7 @@ void cRangeObsermatic::generateVeinInterface()
                                              false);
 
         pParameter->setUnit("");
-        pParameter->setValidator(new cRegExValidator("^[1-9][0-9]*\\/[1-9][0-9]*(\\*\\((sqrt\\(3\\)|1\\/sqrt\\(3\\))\\))?$"));
+        pParameter->setValidator(new cRegExValidator("^[1-9][0-9]*\\/[1-9][0-9]*(\\*\\((1|sqrt\\(3\\)|1\\/sqrt\\(3\\))\\))?$"));
 
 
         m_RangeGroupPreScalingList.append(pParameter);

--- a/modules/rangemodule/lib/rangeobsermatic.cpp
+++ b/modules/rangemodule/lib/rangeobsermatic.cpp
@@ -153,7 +153,8 @@ void cRangeObsermatic::generateVeinInterface()
 
         pParameter->setUnit("");
         pParameter->setValidator(new cRegExValidator("^[1-9][0-9]*\\/[1-9][0-9]*(\\*\\((1|sqrt\\(3\\)|1\\/sqrt\\(3\\))\\))?$"));
-
+        if(m_GroupList.at(i).contains("UL1"))
+            pParameter->setValue("1/1*(1)");
 
         m_RangeGroupPreScalingList.append(pParameter);
         m_pModule->m_veinModuleParameterMap[key] = pParameter;

--- a/modules/rangemodule/tests/test-data/dumpActual-preScaled2.json
+++ b/modules/rangemodule/tests/test-data/dumpActual-preScaled2.json
@@ -879,7 +879,7 @@
         "PAR_Overload": 0,
         "PAR_PreScalingEnabledGroup0": 1,
         "PAR_PreScalingEnabledGroup1": 0,
-        "PAR_PreScalingGroup0": "2/1",
+        "PAR_PreScalingGroup0": "2/1*(1)",
         "PAR_PreScalingGroup1": "1/1",
         "PAR_RangeAutomatic": 0,
         "SIG_Channel1OVL": 0,

--- a/modules/rangemodule/tests/test-data/dumpActual-preScaled2.json
+++ b/modules/rangemodule/tests/test-data/dumpActual-preScaled2.json
@@ -484,14 +484,14 @@
                 "PAR_PreScalingGroup0": {
                     "Description": "Scaling factor for group k (see configuration)",
                     "Validation": {
-                        "Data": "^[1-9][0-9]*\\/[1-9][0-9]*(\\*\\((sqrt\\(3\\)|1\\/sqrt\\(3\\))\\))?$",
+                        "Data": "^[1-9][0-9]*\\/[1-9][0-9]*(\\*\\((1|sqrt\\(3\\)|1\\/sqrt\\(3\\))\\))?$",
                         "Type": "REGEX"
                     }
                 },
                 "PAR_PreScalingGroup1": {
                     "Description": "Scaling factor for group k (see configuration)",
                     "Validation": {
-                        "Data": "^[1-9][0-9]*\\/[1-9][0-9]*(\\*\\((sqrt\\(3\\)|1\\/sqrt\\(3\\))\\))?$",
+                        "Data": "^[1-9][0-9]*\\/[1-9][0-9]*(\\*\\((1|sqrt\\(3\\)|1\\/sqrt\\(3\\))\\))?$",
                         "Type": "REGEX"
                     }
                 },

--- a/modules/rangemodule/tests/test-data/dumpActual.json
+++ b/modules/rangemodule/tests/test-data/dumpActual.json
@@ -879,7 +879,7 @@
         "PAR_Overload": 0,
         "PAR_PreScalingEnabledGroup0": 0,
         "PAR_PreScalingEnabledGroup1": 0,
-        "PAR_PreScalingGroup0": "1/1",
+        "PAR_PreScalingGroup0": "1/1*(1)",
         "PAR_PreScalingGroup1": "1/1",
         "PAR_RangeAutomatic": 0,
         "SIG_Channel1OVL": 0,

--- a/modules/rangemodule/tests/test-data/dumpActual.json
+++ b/modules/rangemodule/tests/test-data/dumpActual.json
@@ -484,14 +484,14 @@
                 "PAR_PreScalingGroup0": {
                     "Description": "Scaling factor for group k (see configuration)",
                     "Validation": {
-                        "Data": "^[1-9][0-9]*\\/[1-9][0-9]*(\\*\\((sqrt\\(3\\)|1\\/sqrt\\(3\\))\\))?$",
+                        "Data": "^[1-9][0-9]*\\/[1-9][0-9]*(\\*\\((1|sqrt\\(3\\)|1\\/sqrt\\(3\\))\\))?$",
                         "Type": "REGEX"
                     }
                 },
                 "PAR_PreScalingGroup1": {
                     "Description": "Scaling factor for group k (see configuration)",
                     "Validation": {
-                        "Data": "^[1-9][0-9]*\\/[1-9][0-9]*(\\*\\((sqrt\\(3\\)|1\\/sqrt\\(3\\))\\))?$",
+                        "Data": "^[1-9][0-9]*\\/[1-9][0-9]*(\\*\\((1|sqrt\\(3\\)|1\\/sqrt\\(3\\))\\))?$",
                         "Type": "REGEX"
                     }
                 },

--- a/modules/rangemodule/tests/test-data/dumpInitial.json
+++ b/modules/rangemodule/tests/test-data/dumpInitial.json
@@ -879,7 +879,7 @@
         "PAR_Overload": 0,
         "PAR_PreScalingEnabledGroup0": 0,
         "PAR_PreScalingEnabledGroup1": 0,
-        "PAR_PreScalingGroup0": "1/1",
+        "PAR_PreScalingGroup0": "1/1*(1)",
         "PAR_PreScalingGroup1": "1/1",
         "PAR_RangeAutomatic": 0,
         "SIG_Channel1OVL": 0,

--- a/modules/rangemodule/tests/test-data/dumpInitial.json
+++ b/modules/rangemodule/tests/test-data/dumpInitial.json
@@ -484,14 +484,14 @@
                 "PAR_PreScalingGroup0": {
                     "Description": "Scaling factor for group k (see configuration)",
                     "Validation": {
-                        "Data": "^[1-9][0-9]*\\/[1-9][0-9]*(\\*\\((sqrt\\(3\\)|1\\/sqrt\\(3\\))\\))?$",
+                        "Data": "^[1-9][0-9]*\\/[1-9][0-9]*(\\*\\((1|sqrt\\(3\\)|1\\/sqrt\\(3\\))\\))?$",
                         "Type": "REGEX"
                     }
                 },
                 "PAR_PreScalingGroup1": {
                     "Description": "Scaling factor for group k (see configuration)",
                     "Validation": {
-                        "Data": "^[1-9][0-9]*\\/[1-9][0-9]*(\\*\\((sqrt\\(3\\)|1\\/sqrt\\(3\\))\\))?$",
+                        "Data": "^[1-9][0-9]*\\/[1-9][0-9]*(\\*\\((1|sqrt\\(3\\)|1\\/sqrt\\(3\\))\\))?$",
                         "Type": "REGEX"
                     }
                 },

--- a/modules/rangemodule/tests/test_range_module_regression.cpp
+++ b/modules/rangemodule/tests/test_range_module_regression.cpp
@@ -91,7 +91,7 @@ void test_range_module_regression::injectActualValuesWithPreScaling()
 {
     ModuleManagerTestRunner testRunner(":/session-range-test.json");
     testRunner.setVfComponent(rangeEntityId, "PAR_PreScalingEnabledGroup0", true);
-    testRunner.setVfComponent(rangeEntityId, "PAR_PreScalingGroup0", "2/1");
+    testRunner.setVfComponent(rangeEntityId, "PAR_PreScalingGroup0", "2/1*(1)");
 
     const QList<TestDspInterfacePtr>& dspInterfaces = testRunner.getDspInterfaceList();
     QCOMPARE(dspInterfaces.count(), 3);


### PR DESCRIPTION
…hat we see '(1)' in the parameter string

When '1' is selected on combo-box, 'PAR_PreScalingGroup' will now show for example '1/1*(1)'