### PR TITLE
apimoduleauthorize, sourcemoduleprogram: Follow changes in vein-frame…

### DIFF
--- a/modules/apimodule/lib/apimoduleauthorize.cpp
+++ b/modules/apimodule/lib/apimoduleauthorize.cpp
@@ -8,6 +8,7 @@
 #include <QFile>
 #include <QUuid>
 #include <scpi.h>
+#include <vcmp_remoteproceduredata.h>
 
 namespace APIMODULE
 {
@@ -123,7 +124,7 @@ void cApiModuleAuthorize::onRpcRejected(QUuid uuid)
 {
     m_sharedPtrRpcAuthenticateInterface->sendRpcResult(
        uuid,
-       VfCpp::cVeinModuleRpc::RPCResultCodes::RPC_EINVAL,
+       VeinComponent::RemoteProcedureData::RPCResultCodes::RPC_EINVAL,
        "trust request already active",
        0
     );
@@ -156,7 +157,7 @@ void cApiModuleAuthorize::onGuiDialogFinished(QVariant dialogFinished)
         m_rpcRequest = QUuid();
 
         m_sharedPtrRpcAuthenticateInterface->sendRpcResult(uuid,
-            VfCpp::cVeinModuleRpc::RPCResultCodes::RPC_SUCCESS,
+            VeinComponent::RemoteProcedureData::RPCResultCodes::RPC_SUCCESS,
             "",
             status
         );

--- a/modules/sourcemodule/lib/module-gluelogic/sourcemoduleprogram.cpp
+++ b/modules/sourcemodule/lib/module-gluelogic/sourcemoduleprogram.cpp
@@ -144,7 +144,7 @@ void SourceModuleProgram::onSourceScanFinished(int slotPosition, QUuid uuid, QSt
         updateDemoCount();
     }
     m_sharedPtrRpcScanInterface->sendRpcResult(uuid,
-                                               sourceAdded ? VfCpp::cVeinModuleRpc::RPCResultCodes::RPC_SUCCESS : VfCpp::cVeinModuleRpc::RPCResultCodes::RPC_EINVAL,
+                                               sourceAdded ? VeinComponent::RemoteProcedureData::RPCResultCodes::RPC_SUCCESS : VeinComponent::RemoteProcedureData::RPCResultCodes::RPC_EINVAL,
                                                errorMsg,
                                                sourceAdded);
 }
@@ -156,7 +156,7 @@ void SourceModuleProgram::onSourceDeviceRemoved(int slot, QUuid uuid, QString er
     if(!uuid.isNull()) {
         bool ok = errorMsg.isEmpty();
         m_sharedPtrRpcRemoveInterface->sendRpcResult(uuid,
-                                                     ok ? VfCpp::cVeinModuleRpc::RPCResultCodes::RPC_SUCCESS : VfCpp::cVeinModuleRpc::RPCResultCodes::RPC_EINVAL,
+                                                     ok ? VeinComponent::RemoteProcedureData::RPCResultCodes::RPC_SUCCESS : VeinComponent::RemoteProcedureData::RPCResultCodes::RPC_EINVAL,
                                                      errorMsg,
                                                      ok);
     }


### PR DESCRIPTION
…work

'RPCResultCodes' is moved to 'VeinComponent::RemoteProcedureData'