### PR TITLE
modulemanager: add a basepath for persistency files (zeragmbh/websam#…

### DIFF
--- a/modulemanager/lib/modulemanager.cpp
+++ b/modulemanager/lib/modulemanager.cpp
@@ -139,7 +139,8 @@ void ModuleManager::createCommonModuleParam()
                                                                    m_serviceInterfaceFactory,
                                                                    m_setupFacade->getStorageSystem(),
                                                                    channelRangeObserver,
-                                                                   m_moduleDemoMode);
+                                                                   m_moduleDemoMode,
+                                                                   m_setupFacade->getPersistencyBasePath());
     }
 }
 

--- a/modulemanager/testlib/sessionexportgenerator.cpp
+++ b/modulemanager/testlib/sessionexportgenerator.cpp
@@ -23,7 +23,8 @@ void SessionExportGenerator::createModman(QString device)
     m_licenseSystem = std::make_unique<TestLicenseSystem>();
     m_modmanSetupFacade = std::make_unique<ModuleManagerSetupFacade>(m_licenseSystem.get(),
                                                                      m_modmanConfig->isDevMode(),
-                                                                     m_lxdmParam);
+                                                                     m_lxdmParam,
+                                                                     "/tmp/" + QUuid::createUuid().toString(QUuid::WithoutBraces));
     m_modman = std::make_unique<TestModuleManager>(m_modmanSetupFacade.get(), std::make_shared<FactoryServiceInterfaces>());
 
     m_modman->loadAllAvailableModulePlugins();

--- a/modules-common/module-qt-plugin-interface/lib/moduleshareddata.cpp
+++ b/modules-common/module-qt-plugin-interface/lib/moduleshareddata.cpp
@@ -5,12 +5,13 @@ int ModuleSharedData::m_instanceCount = 0;
 ModuleSharedData::ModuleSharedData(ModuleNetworkParamsPtr networkParams,
                                    AbstractFactoryServiceInterfacesPtr serviceInterfaceFactory, VeinStorage::AbstractEventSystem *storagesystem,
                                    ChannelRangeObserver::SystemObserverPtr channelRangeObserver,
-                                   bool demo) :
+                                   bool demo, QString persistencyBasePath) :
     m_networkParams(networkParams),
     m_serviceInterfaceFactory(serviceInterfaceFactory),
     m_storagesystem(storagesystem),
     m_channelRangeObserver(channelRangeObserver),
-    m_demo(demo)
+    m_demo(demo),
+    m_persistencyBasePath(persistencyBasePath)
 {
     Q_ASSERT(m_instanceCount == 0); // crashing here: Are there module zombies on session change?
     m_instanceCount++;

--- a/modules-common/module-qt-plugin-interface/lib/moduleshareddata.h
+++ b/modules-common/module-qt-plugin-interface/lib/moduleshareddata.h
@@ -17,7 +17,8 @@ public:
                      AbstractFactoryServiceInterfacesPtr serviceInterfaceFactory,
                      VeinStorage::AbstractEventSystem* storagesystem,
                      ChannelRangeObserver::SystemObserverPtr channelRangeObserver,
-                     bool demo);
+                     bool demo,
+                     QString persistencyBasePath);
     virtual ~ModuleSharedData();
 
     const ModuleNetworkParamsPtr m_networkParams;
@@ -25,6 +26,7 @@ public:
     const VeinStorage::AbstractEventSystem* m_storagesystem;
     const ChannelRangeObserver::SystemObserverPtr m_channelRangeObserver;
     const bool m_demo;
+    const QString m_persistencyBasePath;
 private:
     static int m_instanceCount;
 };

--- a/modules/apimodule/lib/apimodule.cpp
+++ b/modules/apimodule/lib/apimodule.cpp
@@ -19,7 +19,8 @@ namespace APIMODULE
     cApiModule::cApiModule(ModuleFactoryParam moduleParam)
         : BaseModule(moduleParam, std::make_shared<cApiModuleConfiguration>()),
         m_spRpcEventSystem(std::make_shared<VfModuleRpc>(moduleParam.m_entityId)),
-        m_spModuleValidator(std::make_shared<VfEventSytemModuleParam>(moduleParam.m_entityId, moduleParam.m_moduleSharedData->m_storagesystem))
+        m_spModuleValidator(std::make_shared<VfEventSytemModuleParam>(moduleParam.m_entityId, moduleParam.m_moduleSharedData->m_storagesystem)),
+        m_persistencyBasePath(moduleParam.m_moduleSharedData->m_persistencyBasePath)
     {
         m_sModuleName = QString(BaseModuleName);
         m_sModuleDescription = QString("This module supports API access");
@@ -42,7 +43,7 @@ namespace APIMODULE
         emit addEventSystem(m_spRpcEventSystem.get());
         emit addEventSystem(m_pModuleEventSystem);
 
-        cApiModuleAuthorize* moduleActivist = new cApiModuleAuthorize(this);
+        cApiModuleAuthorize* moduleActivist = new cApiModuleAuthorize(this, m_persistencyBasePath);
         m_ModuleActivistList.append(moduleActivist);
 
         BaseModule::setupModule();

--- a/modules/apimodule/lib/apimodule.h
+++ b/modules/apimodule/lib/apimodule.h
@@ -30,6 +30,7 @@ protected:
 
     std::shared_ptr<VfEventSytemModuleParam> m_spModuleValidator;
     std::shared_ptr<VfModuleRpc> m_spRpcEventSystem;
+    QString m_persistencyBasePath;
 };
 
 }

--- a/modules/apimodule/lib/apimoduleauthorize.cpp
+++ b/modules/apimodule/lib/apimoduleauthorize.cpp
@@ -12,9 +12,9 @@
 
 namespace APIMODULE
 {
-    cApiModuleAuthorize::cApiModuleAuthorize(cApiModule *module):
+cApiModuleAuthorize::cApiModuleAuthorize(cApiModule *module, QString persistencyBasePath):
         cModuleActivist(module->getVeinModuleName()),
-        m_trustListPath("/opt/websam-vein-api/authorize/trustlist.json"),
+        m_trustListPath(persistencyBasePath + "/opt/websam-vein-api/authorize/trustlist.json"),
         m_module(module),
         m_bDialogIsOpen(false)
     {

--- a/modules/apimodule/lib/apimoduleauthorize.h
+++ b/modules/apimodule/lib/apimoduleauthorize.h
@@ -14,7 +14,7 @@ class cApiModuleAuthorize : public cModuleActivist
     Q_OBJECT
 
 public:
-    cApiModuleAuthorize(cApiModule *module);
+    cApiModuleAuthorize(cApiModule *module, QString persistencyBasePath);
 public slots:
     void generateVeinInterface() override;
     void activate() override;


### PR DESCRIPTION
…1012)

- enables modules to save files into single subdir
- is transferred via the shared module data