### PR TITLE
Follow changes in vf-logger

### DIFF
--- a/modulemanager/tests/test-data/snapshots/mt310s2-dc-session-ZeraAll.json
+++ b/modulemanager/tests/test-data/snapshots/mt310s2-dc-session-ZeraAll.json
@@ -379,9 +379,6 @@
         "PAR_BluetoothOn": 0,
         "PAR_MacAddress": "00:00:00:00:00:00"
     },
-    "1700": {
-        "PAR_EmobPushButton": 0
-    },
     "Contentsets": [
         "ZeraActualValues",
         "ZeraComparison",

--- a/modulemanager/tests/test-data/snapshots/mt310s2-emob-session-ac-ZeraAll.json
+++ b/modulemanager/tests/test-data/snapshots/mt310s2-emob-session-ac-ZeraAll.json
@@ -412,9 +412,6 @@
     "1600": {
         "ACT_PowerAboveLimit": 0
     },
-    "1700": {
-        "PAR_EmobPushButton": 0
-    },
     "Contentsets": [
         "ZeraActualValues",
         "ZeraComparison",

--- a/modulemanager/tests/test-data/snapshots/mt310s2-emob-session-dc-ZeraAll.json
+++ b/modulemanager/tests/test-data/snapshots/mt310s2-emob-session-dc-ZeraAll.json
@@ -341,9 +341,6 @@
     "1600": {
         "ACT_PowerAboveLimit": 0
     },
-    "1700": {
-        "PAR_EmobPushButton": 0
-    },
     "Contentsets": [
         "ZeraActualValues",
         "ZeraComparison",

--- a/modulemanager/tests/test-data/snapshots/mt310s2-meas-session-ZeraAll.json
+++ b/modulemanager/tests/test-data/snapshots/mt310s2-meas-session-ZeraAll.json
@@ -513,9 +513,6 @@
     "1600": {
         "ACT_PowerAboveLimit": 0
     },
-    "1700": {
-        "PAR_EmobPushButton": 0
-    },
     "Contentsets": [
         "ZeraActualValues",
         "ZeraBurden",


### PR DESCRIPTION
'hotplugcontrolsmodule' is not logged with ZeraAll content set